### PR TITLE
feat: implement Tier A detection and `dedup scan` (#3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,198 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "dedup-cli"
 version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "clap",
+ "dedup-core",
+ "insta",
+]
 
 [[package]]
 name = "dedup-core"
 version = "0.1.0"
+dependencies = [
+ "insta",
+ "proptest",
+ "rustc-hash",
+ "tempfile",
+ "thiserror",
+ "walkdir",
+]
 
 [[package]]
 name = "dedup-gui"
@@ -17,3 +203,728 @@ version = "0.1.0"
 [[package]]
 name = "dedup-lang"
 version = "0.1.0"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/dedup-cli/Cargo.toml
+++ b/crates/dedup-cli/Cargo.toml
@@ -12,3 +12,9 @@ name = "dedup"
 path = "src/main.rs"
 
 [dependencies]
+clap = { version = "4", features = ["derive"] }
+dedup-core = { path = "../dedup-core" }
+
+[dev-dependencies]
+assert_cmd = "2"
+insta = "1"

--- a/crates/dedup-cli/src/main.rs
+++ b/crates/dedup-cli/src/main.rs
@@ -1,3 +1,82 @@
-fn main() {
-    println!("Hello, world!");
+//! `dedup` CLI entry point.
+//!
+//! Only the `scan` subcommand exists at this milestone. Other subcommands
+//! (`list`, `show`, `dismiss`, `config`, ...) land in later issues.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+use dedup_core::{ScanConfig, Scanner};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "dedup",
+    about = "Find duplicate code across a directory tree",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Scan a directory tree for duplicate code and print match groups.
+    Scan {
+        /// Directory to scan. Defaults to the current directory.
+        #[arg(default_value = ".")]
+        path: PathBuf,
+    },
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Scan { path } => run_scan(&path),
+    }
+}
+
+fn run_scan(path: &std::path::Path) -> ExitCode {
+    let scanner = Scanner::new(ScanConfig::default());
+    let result = match scanner.scan(path) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("dedup: scan failed: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    print_groups(&result, &mut std::io::stdout()).ok();
+
+    // Exit code 0 whether duplicates are found or not (git-style default,
+    // per the PRD). `--strict` lands in #13.
+    ExitCode::SUCCESS
+}
+
+fn print_groups<W: std::io::Write>(
+    result: &dedup_core::ScanResult,
+    out: &mut W,
+) -> std::io::Result<()> {
+    for (i, group) in result.groups.iter().enumerate() {
+        writeln!(
+            out,
+            "--- group {} ({} occurrences) ---",
+            i + 1,
+            group.occurrences.len()
+        )?;
+        for occ in &group.occurrences {
+            // Use forward-slashed display so snapshots are stable across
+            // platforms. `Path::display()` uses the native separator on
+            // Windows (we don't target Windows in this milestone, but
+            // being safe is cheap).
+            let path = occ.path.to_string_lossy().replace('\\', "/");
+            writeln!(
+                out,
+                "{}:{}-{}",
+                path, occ.span.start_line, occ.span.end_line
+            )?;
+        }
+    }
+    Ok(())
 }

--- a/crates/dedup-cli/tests/scan_snapshot.rs
+++ b/crates/dedup-cli/tests/scan_snapshot.rs
@@ -1,0 +1,33 @@
+//! Snapshot test for `dedup scan <fixture>`.
+//!
+//! Invokes the compiled `dedup` binary against `fixtures/tier_a_basic/`
+//! and compares stdout to a committed `insta` snapshot. If the scanner
+//! output format or the fixture drifts, the snapshot test loudly fails
+//! and a human has to `cargo insta review` the change.
+
+use std::path::PathBuf;
+
+use assert_cmd::Command;
+
+fn workspace_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // dedup-cli → crates
+    p.pop(); // crates    → workspace root
+    p
+}
+
+#[test]
+fn scan_fixture_snapshot() {
+    let fixture = workspace_root().join("fixtures").join("tier_a_basic");
+
+    let output = Command::cargo_bin("dedup")
+        .expect("dedup binary")
+        .arg("scan")
+        .arg(&fixture)
+        .output()
+        .expect("dedup scan");
+
+    assert!(output.status.success(), "dedup scan failed: {:?}", output);
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    insta::assert_snapshot!("scan_tier_a_basic", stdout);
+}

--- a/crates/dedup-cli/tests/snapshots/scan_snapshot__scan_tier_a_basic.snap
+++ b/crates/dedup-cli/tests/snapshots/scan_snapshot__scan_tier_a_basic.snap
@@ -1,0 +1,8 @@
+---
+source: crates/dedup-cli/tests/scan_snapshot.rs
+expression: stdout
+---
+--- group 1 (3 occurrences) ---
+alpha.rs:5-23
+beta.rs:4-22
+gamma.rs:11-29

--- a/crates/dedup-core/Cargo.toml
+++ b/crates/dedup-core/Cargo.toml
@@ -8,3 +8,11 @@ repository.workspace = true
 description = "Core detection, normalization, and persistence primitives for dedup."
 
 [dependencies]
+rustc-hash = "2"
+thiserror = "2"
+walkdir = "2"
+
+[dev-dependencies]
+insta = "1"
+proptest = "1"
+tempfile = "3"

--- a/crates/dedup-core/src/lib.rs
+++ b/crates/dedup-core/src/lib.rs
@@ -1,3 +1,28 @@
 //! Core detection, normalization, and persistence primitives for dedup.
 //!
 //! This crate is frontend-agnostic; the CLI and GUI both depend on it.
+//!
+//! At this milestone the public API is a single Tier A scanner:
+//!
+//! ```no_run
+//! use dedup_core::{Scanner, ScanConfig};
+//! use std::path::Path;
+//!
+//! let scanner = Scanner::new(ScanConfig::default());
+//! let result = scanner.scan(Path::new(".")).expect("scan");
+//! for group in &result.groups {
+//!     println!("{} occurrences", group.occurrences.len());
+//! }
+//! ```
+//!
+//! The three deep modules (`tokenizer`, `rolling_hash`, `scanner`) are
+//! each testable in isolation. Later milestones add cache (#4), tree-sitter
+//! Tier B (#6), `ignore`-crate layers (#5), parallelism (#14), and so on.
+
+pub mod rolling_hash;
+pub mod scanner;
+pub mod tokenizer;
+
+pub use rolling_hash::{Hash, Span};
+pub use scanner::{MatchGroup, Occurrence, ScanConfig, ScanError, ScanResult, Scanner};
+pub use tokenizer::{Token, TokenKind};

--- a/crates/dedup-core/src/rolling_hash.rs
+++ b/crates/dedup-core/src/rolling_hash.rs
@@ -1,0 +1,248 @@
+//! Rabin-Karp-style rolling hash over token n-grams.
+//!
+//! Given a slice of [`Token`]s and a window size `n`, emits one [`Hash`] per
+//! length-`n` window, paired with the [`Span`] covered by that window. The
+//! hash is a 64-bit polynomial rolling hash computed over each token's
+//! canonical content (`kind` tag + normalized text). Two windows that hash
+//! equal are almost certainly the same token sequence; downstream code
+//! should still do an exact token-stream compare for confirmed matches
+//! (Tier B / #6 handles that; Tier A as specified in the PRD tolerates
+//! the false-positive risk).
+//!
+//! Pure and deterministic: no randomness, no global state.
+
+use crate::tokenizer::{Token, TokenKind};
+
+/// 64-bit window hash.
+pub type Hash = u64;
+
+/// The source region covered by a rolling-hash window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    /// 1-based line of the first token in the window.
+    pub start_line: usize,
+    /// 1-based line of the last token in the window.
+    pub end_line: usize,
+    /// Byte offset (inclusive) of the first token.
+    pub start_byte: usize,
+    /// Byte offset (exclusive) of the last token.
+    pub end_byte: usize,
+}
+
+/// Mixing constants for the polynomial rolling hash. Chosen as a large odd
+/// multiplier and a non-trivial seed so empty windows still hash distinctly.
+const MUL: u64 = 0x100000001b3; // FNV-1a prime; works fine as a polynomial base.
+const SEED: u64 = 0xcbf29ce484222325;
+
+/// Compute the canonical per-token hash contribution.
+#[inline]
+fn token_hash(tok: &Token) -> u64 {
+    // Kind tag so `identifier x` and `string x` don't collide.
+    let kind_tag: u64 = match tok.kind {
+        TokenKind::Identifier => 1,
+        TokenKind::Number => 2,
+        TokenKind::String => 3,
+        TokenKind::Punct => 4,
+    };
+    let mut h = SEED ^ kind_tag;
+    for &b in tok.text.as_bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(MUL);
+    }
+    h
+}
+
+/// Roll a window of size `n` across `tokens` and emit `(hash, span)` pairs.
+///
+/// Returns an empty vector if `n == 0` or `tokens.len() < n`.
+pub fn rolling_hash(tokens: &[Token], n: usize) -> Vec<(Hash, Span)> {
+    if n == 0 || tokens.len() < n {
+        return Vec::new();
+    }
+
+    // Per-token hash table.
+    let hashes: Vec<u64> = tokens.iter().map(token_hash).collect();
+
+    // The multiplier raised to the window length, used to subtract the
+    // departing token's contribution when sliding.
+    let mut mul_n: u64 = 1;
+    for _ in 0..n {
+        mul_n = mul_n.wrapping_mul(MUL);
+    }
+
+    let mut out = Vec::with_capacity(tokens.len() - n + 1);
+
+    // Seed the first window.
+    let mut acc: u64 = 0;
+    for h in hashes.iter().take(n) {
+        acc = acc.wrapping_mul(MUL).wrapping_add(*h);
+    }
+
+    let push = |out: &mut Vec<(Hash, Span)>, acc: u64, start_idx: usize| {
+        let first = &tokens[start_idx];
+        let last = &tokens[start_idx + n - 1];
+        out.push((
+            acc,
+            Span {
+                start_line: first.line,
+                end_line: last.line,
+                start_byte: first.start,
+                end_byte: last.end,
+            },
+        ));
+    };
+
+    push(&mut out, acc, 0);
+
+    // Slide the window: for each new end index, drop the departing token
+    // and mix in the new one. `acc_{i+1} = acc_i * MUL - out * MUL^n + in`.
+    for i in 1..=tokens.len() - n {
+        let out_hash = hashes[i - 1];
+        let in_hash = hashes[i + n - 1];
+        acc = acc
+            .wrapping_mul(MUL)
+            .wrapping_sub(out_hash.wrapping_mul(mul_n))
+            .wrapping_add(in_hash);
+        push(&mut out, acc, i);
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokenizer::tokenize;
+
+    #[test]
+    fn empty_when_window_larger_than_input() {
+        let toks = tokenize("a b c");
+        assert!(rolling_hash(&toks, 4).is_empty());
+    }
+
+    #[test]
+    fn empty_when_n_zero() {
+        let toks = tokenize("a b c");
+        assert!(rolling_hash(&toks, 0).is_empty());
+    }
+
+    #[test]
+    fn exact_one_window_when_equal_length() {
+        let toks = tokenize("a b c");
+        let hs = rolling_hash(&toks, 3);
+        assert_eq!(hs.len(), 1);
+    }
+
+    #[test]
+    fn same_tokens_hash_equal() {
+        let a = tokenize("fn foo(x: i32) { return x + 1; }");
+        let b = tokenize("fn foo(x: i32) { return x + 1; }");
+        let ha = rolling_hash(&a, 4);
+        let hb = rolling_hash(&b, 4);
+        assert_eq!(
+            ha.iter().map(|(h, _)| *h).collect::<Vec<_>>(),
+            hb.iter().map(|(h, _)| *h).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn different_tokens_hash_distinct() {
+        let a = rolling_hash(&tokenize("a b c d"), 3);
+        let b = rolling_hash(&tokenize("a b c e"), 3);
+        // At least one of the overlapping windows must differ.
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn span_byte_ranges_cover_input() {
+        let src = "alpha beta gamma";
+        let toks = tokenize(src);
+        let hs = rolling_hash(&toks, 3);
+        assert_eq!(hs.len(), 1);
+        let span = hs[0].1;
+        assert_eq!(&src[span.start_byte..span.end_byte], "alpha beta gamma");
+    }
+
+    #[test]
+    fn sliding_hash_matches_naive_recompute() {
+        // For each window position, the rolling accumulator should equal
+        // the polynomial hash recomputed from scratch over the same window.
+        let src = "a b c d e f g h i j";
+        let toks = tokenize(src);
+        let rolled = rolling_hash(&toks, 4);
+        for (i, (rolled_h, _)) in rolled.iter().enumerate() {
+            let mut acc: u64 = 0;
+            for tok in &toks[i..i + 4] {
+                acc = acc.wrapping_mul(MUL).wrapping_add(token_hash(tok));
+            }
+            assert_eq!(*rolled_h, acc, "mismatch at window {i}");
+        }
+    }
+
+    // --- proptest invariants -------------------------------------------------
+
+    use proptest::prelude::*;
+
+    fn ident_source() -> impl Strategy<Value = String> {
+        proptest::collection::vec(
+            prop_oneof![
+                Just("a"),
+                Just("b"),
+                Just("c"),
+                Just("d"),
+                Just("e"),
+                Just("+"),
+                Just(";"),
+                Just("("),
+                Just(")"),
+                Just(" "),
+                Just("\n"),
+            ],
+            3..60,
+        )
+        .prop_map(|v| v.into_iter().collect::<String>())
+    }
+
+    proptest! {
+        /// Determinism: same input → same output, byte-for-byte.
+        #[test]
+        fn stable_under_identical_input(src in ident_source(), n in 1usize..6) {
+            let toks = tokenize(&src);
+            prop_assert_eq!(rolling_hash(&toks, n), rolling_hash(&toks, n));
+        }
+
+        /// Each emitted span must cover exactly n tokens and the recovered
+        /// byte range must start at tokens[i].start and end at tokens[i+n-1].end.
+        #[test]
+        fn span_covers_exactly_n_tokens(src in ident_source(), n in 1usize..6) {
+            let toks = tokenize(&src);
+            let hs = rolling_hash(&toks, n);
+            if toks.len() < n {
+                prop_assert!(hs.is_empty());
+                return Ok(());
+            }
+            prop_assert_eq!(hs.len(), toks.len() - n + 1);
+            for (i, (_, span)) in hs.iter().enumerate() {
+                prop_assert_eq!(span.start_byte, toks[i].start);
+                prop_assert_eq!(span.end_byte, toks[i + n - 1].end);
+                prop_assert_eq!(span.start_line, toks[i].line);
+                prop_assert_eq!(span.end_line, toks[i + n - 1].line);
+            }
+        }
+
+        /// Rolling the window one step at a time must agree with recomputing
+        /// the polynomial hash from scratch at each position.
+        #[test]
+        fn rolling_matches_direct_computation(src in ident_source(), n in 1usize..6) {
+            let toks = tokenize(&src);
+            let hs = rolling_hash(&toks, n);
+            for (i, (rolled, _)) in hs.iter().enumerate() {
+                let mut acc: u64 = 0;
+                for tok in &toks[i..i + n] {
+                    acc = acc.wrapping_mul(MUL).wrapping_add(token_hash(tok));
+                }
+                prop_assert_eq!(*rolled, acc);
+            }
+        }
+    }
+}

--- a/crates/dedup-core/src/scanner.rs
+++ b/crates/dedup-core/src/scanner.rs
@@ -1,0 +1,422 @@
+//! Tier A scanner: walks files, rolls hashes, buckets match groups.
+//!
+//! The scanner is the top-level orchestrator for this milestone. It:
+//!
+//! 1. Walks `root` with [`walkdir`], skipping `.git/` directories and binary
+//!    files (content-sniffed via the first 512 bytes).
+//! 2. Reads each file as UTF-8 (silently skips decode failures — the PRD
+//!    says skip at debug level; logging lands in #16).
+//! 3. Tokenizes, then runs a fixed-window rolling hash with window size 50
+//!    (the Tier A `min_tokens` default).
+//! 4. Buckets windows by hash across all files, keeping only buckets with
+//!    ≥ 2 members after collection.
+//! 5. Greedily extends adjacent matching windows in each file into maximal
+//!    spans, then filters by the `min_lines` / `min_tokens` thresholds.
+//! 6. Emits [`MatchGroup`]s — one per cluster of equivalent extended spans
+//!    across files — suitable for the CLI to print or for later issues
+//!    (#4 cache, #12 formats) to consume.
+//!
+//! What this scanner deliberately does NOT do at this milestone:
+//!
+//! - No cache (lands in #4).
+//! - No `ignore`-crate layers (lands in #5): we honor only the hard-coded
+//!   binary + `.git/` skip.
+//! - No parallelism (lands in #14).
+//! - No tree-sitter Tier B (lands in #6).
+//! - No typed-error surfacing for per-file I/O failures: they are silently
+//!   skipped. `ScanError` exists for top-level catastrophic failures
+//!   (none today, but the surface is ready for #17).
+
+use crate::rolling_hash::{Hash, Span, rolling_hash};
+use crate::tokenizer::{Token, tokenize};
+use rustc_hash::FxHashMap;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use walkdir::WalkDir;
+
+/// The rolling-hash window size. Matches the Tier A `min_tokens` default.
+const WINDOW_SIZE: usize = 50;
+
+/// Number of leading bytes inspected for binary content-sniff.
+const BINARY_SNIFF_BYTES: usize = 512;
+
+/// Errors the scanner can emit. All per-file errors today are silently
+/// skipped; this enum exists so the API surface is stable as later issues
+/// add real failure modes.
+#[derive(Debug, Error)]
+pub enum ScanError {
+    /// The root path does not exist or cannot be walked.
+    #[error("failed to walk {path}: {source}")]
+    Walk {
+        path: PathBuf,
+        #[source]
+        source: walkdir::Error,
+    },
+}
+
+/// Tunable scanner knobs. Defaults mirror the Tier A thresholds from the PRD.
+#[derive(Debug, Clone)]
+pub struct ScanConfig {
+    /// A match span must cover at least this many lines to be reported.
+    pub tier_a_min_lines: usize,
+    /// A match span must cover at least this many tokens to be reported.
+    pub tier_a_min_tokens: usize,
+}
+
+impl Default for ScanConfig {
+    fn default() -> Self {
+        Self {
+            tier_a_min_lines: 6,
+            tier_a_min_tokens: 50,
+        }
+    }
+}
+
+/// One file-local occurrence of a duplicate block.
+#[derive(Debug, Clone)]
+pub struct Occurrence {
+    /// Path relative to the scan root (always uses forward slashes on all
+    /// platforms so snapshot output is cross-platform-stable).
+    pub path: PathBuf,
+    /// Source region covered.
+    pub span: Span,
+}
+
+/// A cluster of file-local occurrences that share the same canonical
+/// token stream.
+#[derive(Debug, Clone)]
+pub struct MatchGroup {
+    /// Representative hash for the extended span (the hash of the first
+    /// rolling window in the span; good enough for grouping at Tier A).
+    pub hash: Hash,
+    /// All file-local occurrences; always `len() >= 2` after filtering.
+    pub occurrences: Vec<Occurrence>,
+}
+
+/// Result of a single [`Scanner::scan`] call.
+#[derive(Debug, Clone)]
+pub struct ScanResult {
+    /// Confirmed match groups, sorted for deterministic output:
+    /// by first occurrence path, then start line.
+    pub groups: Vec<MatchGroup>,
+    /// Count of files that were actually tokenized (binary + `.git/` skipped
+    /// files do not count).
+    pub files_scanned: usize,
+}
+
+/// Public scanner handle. Cheap to construct; holds only configuration.
+#[derive(Debug, Clone, Default)]
+pub struct Scanner {
+    config: ScanConfig,
+}
+
+impl Scanner {
+    /// Build a scanner with explicit configuration.
+    pub fn new(config: ScanConfig) -> Self {
+        Self { config }
+    }
+
+    /// Walk `root` and return all Tier A match groups.
+    pub fn scan(&self, root: &Path) -> Result<ScanResult, ScanError> {
+        // --- 1. Walk and tokenize each candidate file. --------------------
+        let mut per_file: Vec<(PathBuf, Vec<Token>)> = Vec::new();
+
+        for entry in WalkDir::new(root).into_iter().filter_entry(|e| {
+            // Skip `.git/` directories wholesale.
+            !(e.file_type().is_dir() && e.file_name() == ".git")
+        }) {
+            let entry = match entry {
+                Ok(e) => e,
+                // Tolerate per-entry walk errors (permission denied on a
+                // sibling, symlink loop, ...) so one bad file doesn't kill
+                // the scan. Logging lives in #16.
+                Err(_) => continue,
+            };
+            if !entry.file_type().is_file() {
+                continue;
+            }
+
+            let abs = entry.path();
+            let bytes = match std::fs::read(abs) {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            if looks_binary(&bytes) {
+                continue;
+            }
+            let text = match std::str::from_utf8(&bytes) {
+                Ok(s) => s.to_string(),
+                Err(_) => continue,
+            };
+
+            let rel = abs.strip_prefix(root).unwrap_or(abs).to_path_buf();
+            per_file.push((rel, tokenize(&text)));
+        }
+
+        let files_scanned = per_file.len();
+
+        // --- 2. Roll hashes per file and index them. ----------------------
+        // Each window is uniquely identified by (file_index, window_start).
+        #[derive(Clone, Copy)]
+        struct WindowKey {
+            file: usize,
+            win: usize,
+        }
+
+        let mut by_hash: FxHashMap<Hash, Vec<WindowKey>> = FxHashMap::default();
+        let mut per_file_hashes: Vec<Vec<(Hash, Span)>> = Vec::with_capacity(per_file.len());
+
+        for (fi, (_path, tokens)) in per_file.iter().enumerate() {
+            let windows = rolling_hash(tokens, WINDOW_SIZE);
+            for (wi, (h, _)) in windows.iter().enumerate() {
+                by_hash
+                    .entry(*h)
+                    .or_default()
+                    .push(WindowKey { file: fi, win: wi });
+            }
+            per_file_hashes.push(windows);
+        }
+
+        // --- 3. Drop singleton buckets. ----------------------------------
+        by_hash.retain(|_, v| v.len() >= 2);
+
+        // --- 4. Greedy extension.
+        //
+        // A "seed" is any window whose hash has ≥ 2 matching windows across
+        // the corpus. For each file, we walk its windows in order and grow
+        // runs where every window in the run has the *same* set of
+        // counterpart (file, win) keys. Two seed windows `i` and `i+1` can
+        // merge only if sliding both forward stays aligned in every peer.
+        //
+        // This is a simple O(F * W) pass over windows plus O(peer_count)
+        // per extension step. It is correct for the common case
+        // (copy-pasted blocks with identical token surroundings); blocks
+        // that match only partially end up as multiple shorter groups,
+        // which is acceptable at Tier A.
+        #[derive(Debug, Clone)]
+        struct ExtendedSpan {
+            start_win: usize,
+            end_win: usize, // inclusive
+            hash: Hash,
+        }
+
+        let mut consumed: Vec<Vec<bool>> = per_file_hashes
+            .iter()
+            .map(|h| vec![false; h.len()])
+            .collect();
+        let mut extended: Vec<Vec<ExtendedSpan>> =
+            (0..per_file.len()).map(|_| Vec::new()).collect();
+
+        for fi in 0..per_file.len() {
+            let windows = &per_file_hashes[fi];
+            let mut wi = 0usize;
+            while wi < windows.len() {
+                if consumed[fi][wi] {
+                    wi += 1;
+                    continue;
+                }
+                let h = windows[wi].0;
+                let peers = match by_hash.get(&h) {
+                    Some(p) if p.len() >= 2 => p,
+                    _ => {
+                        wi += 1;
+                        continue;
+                    }
+                };
+
+                // Peers aligned at offset 0 (all `WindowKey`s matching the
+                // seed hash, *including* ourselves). We track a cursor per
+                // peer so we can check if the peer also has a matching
+                // continuation at each extension step.
+                let start = wi;
+                let mut end = wi;
+                let seed_peers: Vec<WindowKey> = peers.clone();
+
+                'outer: loop {
+                    let next = end + 1;
+                    if next >= windows.len() {
+                        break;
+                    }
+                    let next_hash = windows[next].0;
+                    // Every seed peer must also extend to the next hash in
+                    // its own file, at the next window offset, AND those
+                    // extensions must all share the same hash `next_hash`.
+                    for peer in &seed_peers {
+                        let peer_windows = &per_file_hashes[peer.file];
+                        let peer_next = peer.win + (next - start);
+                        if peer_next >= peer_windows.len() {
+                            break 'outer;
+                        }
+                        if peer_windows[peer_next].0 != next_hash {
+                            break 'outer;
+                        }
+                    }
+                    end = next;
+                }
+
+                // Record extended spans for the whole cluster so every
+                // peer's windows are marked consumed. We only push the
+                // span for the *current* file here; peers are pushed when
+                // their own outer-loop iteration reaches them. That would
+                // normally double-emit, so we guard via `consumed`.
+                let cluster_hash = h;
+                for peer in &seed_peers {
+                    let plen = end - start;
+                    let pe_start = peer.win;
+                    let pe_end = peer.win + plen;
+                    // Bounds-guard: the alignment check above guarantees
+                    // `pe_end < per_file_hashes[peer.file].len()`.
+                    for slot in consumed[peer.file][pe_start..=pe_end].iter_mut() {
+                        *slot = true;
+                    }
+                    extended[peer.file].push(ExtendedSpan {
+                        start_win: pe_start,
+                        end_win: pe_end,
+                        hash: cluster_hash,
+                    });
+                }
+
+                wi = end + 1;
+            }
+        }
+
+        // --- 5. Group extended spans back together by cluster hash. ------
+        // Two extended spans are in the same cluster iff they share the
+        // seed hash *and* the same length. (Different seed hashes can
+        // theoretically extend to the same material, but at Tier A we
+        // trust the hash as a cluster key.)
+        let mut clusters: FxHashMap<(Hash, usize), Vec<Occurrence>> = FxHashMap::default();
+        for (fi, spans) in extended.iter().enumerate() {
+            for s in spans {
+                let (path, tokens) = &per_file[fi];
+                let windows = &per_file_hashes[fi];
+                let first_span = windows[s.start_win].1;
+                let last_span = windows[s.end_win].1;
+                let combined = Span {
+                    start_line: first_span.start_line,
+                    end_line: last_span.end_line,
+                    start_byte: first_span.start_byte,
+                    end_byte: last_span.end_byte,
+                };
+
+                let tokens_covered =
+                    token_count_between(tokens, combined.start_byte, combined.end_byte);
+                let lines_covered = combined.end_line.saturating_sub(combined.start_line) + 1;
+
+                if lines_covered < self.config.tier_a_min_lines {
+                    continue;
+                }
+                if tokens_covered < self.config.tier_a_min_tokens {
+                    continue;
+                }
+
+                let key = (s.hash, s.end_win - s.start_win);
+                clusters.entry(key).or_default().push(Occurrence {
+                    path: path.clone(),
+                    span: combined,
+                });
+            }
+        }
+
+        // --- 6. Finalize: keep only ≥ 2-occurrence clusters and sort. ----
+        let mut groups: Vec<MatchGroup> = clusters
+            .into_iter()
+            .filter(|(_, occ)| occ.len() >= 2)
+            .map(|((hash, _), mut occ)| {
+                occ.sort_by(|a, b| {
+                    a.path
+                        .cmp(&b.path)
+                        .then(a.span.start_line.cmp(&b.span.start_line))
+                });
+                MatchGroup {
+                    hash,
+                    occurrences: occ,
+                }
+            })
+            .collect();
+
+        groups.sort_by(|a, b| {
+            let ap = &a.occurrences[0];
+            let bp = &b.occurrences[0];
+            ap.path
+                .cmp(&bp.path)
+                .then(ap.span.start_line.cmp(&bp.span.start_line))
+        });
+
+        Ok(ScanResult {
+            groups,
+            files_scanned,
+        })
+    }
+}
+
+/// Count how many tokens fall within `[start_byte, end_byte)`.
+///
+/// Tokens are stored in source order, so this is a simple linear scan; it
+/// runs once per candidate match group, not per window.
+fn token_count_between(tokens: &[Token], start_byte: usize, end_byte: usize) -> usize {
+    tokens
+        .iter()
+        .filter(|t| t.start >= start_byte && t.end <= end_byte)
+        .count()
+}
+
+/// Content-sniff for binary files: look at the first [`BINARY_SNIFF_BYTES`]
+/// bytes and treat the file as binary if any NUL byte is present. This is
+/// the same heuristic `git` and `ripgrep` use for their "is binary?" check.
+fn looks_binary(bytes: &[u8]) -> bool {
+    bytes.iter().take(BINARY_SNIFF_BYTES).any(|&b| b == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn binary_sniff_detects_nul() {
+        assert!(looks_binary(b"hello\0world"));
+        assert!(!looks_binary(b"hello world"));
+    }
+
+    #[test]
+    fn empty_directory_yields_no_groups() {
+        let dir = tempdir().unwrap();
+        let r = Scanner::default().scan(dir.path()).unwrap();
+        assert_eq!(r.files_scanned, 0);
+        assert!(r.groups.is_empty());
+    }
+
+    #[test]
+    fn git_directory_is_skipped() {
+        let dir = tempdir().unwrap();
+        let git = dir.path().join(".git");
+        fs::create_dir_all(&git).unwrap();
+        fs::write(git.join("config"), "some git config").unwrap();
+        fs::write(dir.path().join("visible.txt"), "hello").unwrap();
+
+        let r = Scanner::default().scan(dir.path()).unwrap();
+        assert_eq!(r.files_scanned, 1);
+    }
+
+    #[test]
+    fn binary_files_are_skipped() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("binary.bin"), b"\0\0\0\0data").unwrap();
+        fs::write(dir.path().join("text.txt"), "hello world").unwrap();
+
+        let r = Scanner::default().scan(dir.path()).unwrap();
+        assert_eq!(r.files_scanned, 1);
+    }
+
+    #[test]
+    fn tiny_file_under_threshold_is_not_reported() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("a.txt"), "x y z").unwrap();
+        fs::write(dir.path().join("b.txt"), "x y z").unwrap();
+
+        let r = Scanner::default().scan(dir.path()).unwrap();
+        assert!(r.groups.is_empty());
+    }
+}

--- a/crates/dedup-core/src/tokenizer.rs
+++ b/crates/dedup-core/src/tokenizer.rs
@@ -1,0 +1,435 @@
+//! Language-oblivious tokenizer for Tier A detection.
+//!
+//! Splits source text into [`Token`]s of four kinds (identifier, number, string,
+//! punctuation) while stripping whitespace and comments. Comment heuristics
+//! cover the pragmatic set of languages used in most real-world codebases:
+//! `//` line comments, `/* ... */` block comments (C / JS / TS / Rust / Go /
+//! Swift / Kotlin), and `#` line comments (Python / shell / Ruby / TOML / YAML).
+//! String literals use `"..."` or `'...'` delimiters with a single-character
+//! `\` escape. The tokenizer is intentionally permissive: Tier A is a
+//! heuristic pass, and false positives / false negatives on pathological
+//! input (e.g. a `#` inside a Rust attribute) are acceptable per the PRD.
+
+/// Kind of a lexical token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TokenKind {
+    /// An identifier: `[A-Za-z_][A-Za-z0-9_]*` (plus non-ASCII letters).
+    Identifier,
+    /// A numeric literal: `[0-9]` followed by any `[A-Za-z0-9_.]` run.
+    Number,
+    /// A string literal, delimiter-included, quotes preserved verbatim.
+    String,
+    /// Any other non-whitespace byte (operator, bracket, comma, ...).
+    Punct,
+}
+
+/// A single lexical token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Token {
+    /// What sort of token this is.
+    pub kind: TokenKind,
+    /// Start byte offset (inclusive) into the source.
+    pub start: usize,
+    /// End byte offset (exclusive) into the source.
+    pub end: usize,
+    /// 1-based line number the token starts on.
+    pub line: usize,
+    /// Lexeme text, verbatim (including quotes for strings).
+    pub text: String,
+}
+
+/// Tokenize `source` into a whitespace-and-comment-stripped token stream.
+///
+/// Lines are 1-based. Byte offsets are relative to the start of `source`.
+pub fn tokenize(source: &str) -> Vec<Token> {
+    let bytes = source.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    let mut line = 1usize;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        // Newline: advance the line counter.
+        if b == b'\n' {
+            line += 1;
+            i += 1;
+            continue;
+        }
+
+        // Other whitespace: skip.
+        if b.is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+
+        // `//` line comment.
+        if b == b'/' && bytes.get(i + 1) == Some(&b'/') {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        // `/* ... */` block comment.
+        if b == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                if bytes[i] == b'\n' {
+                    line += 1;
+                }
+                i += 1;
+            }
+            // Consume the closing `*/` if present (unterminated comments eat to EOF).
+            if i + 1 < bytes.len() {
+                i += 2;
+            } else {
+                i = bytes.len();
+            }
+            continue;
+        }
+
+        // `#` line comment (Python / shell / Ruby / TOML / YAML).
+        if b == b'#' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        // String literal `"..."` or `'...'` with `\` escapes.
+        if b == b'"' || b == b'\'' {
+            let quote = b;
+            let start = i;
+            let start_line = line;
+            i += 1;
+            while i < bytes.len() && bytes[i] != quote {
+                if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                    if bytes[i + 1] == b'\n' {
+                        line += 1;
+                    }
+                    i += 2;
+                    continue;
+                }
+                if bytes[i] == b'\n' {
+                    line += 1;
+                }
+                i += 1;
+            }
+            // Consume the closing quote if present.
+            if i < bytes.len() {
+                i += 1;
+            }
+            out.push(Token {
+                kind: TokenKind::String,
+                start,
+                end: i,
+                line: start_line,
+                text: source[start..i].to_string(),
+            });
+            continue;
+        }
+
+        // Numeric literal: ASCII digit run, plus identifier-continuation bytes
+        // so things like `0x1F`, `1_000`, `3.14`, `1e-3` stay one token. The
+        // exponent-sign case (`1e-3`) requires a tiny lookahead.
+        if b.is_ascii_digit() {
+            let start = i;
+            let start_line = line;
+            while i < bytes.len() {
+                let c = bytes[i];
+                let is_cont = c.is_ascii_alphanumeric() || c == b'_' || c == b'.';
+                let is_exp_sign = (c == b'+' || c == b'-')
+                    && i > start
+                    && (bytes[i - 1] == b'e' || bytes[i - 1] == b'E');
+                if is_cont || is_exp_sign {
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            out.push(Token {
+                kind: TokenKind::Number,
+                start,
+                end: i,
+                line: start_line,
+                text: source[start..i].to_string(),
+            });
+            continue;
+        }
+
+        // Identifier: leading ASCII letter or `_`, or any non-ASCII UTF-8 lead byte.
+        if is_ident_start(b) {
+            let start = i;
+            let start_line = line;
+            while i < bytes.len() && is_ident_continue(bytes[i]) {
+                i += 1;
+            }
+            out.push(Token {
+                kind: TokenKind::Identifier,
+                start,
+                end: i,
+                line: start_line,
+                text: source[start..i].to_string(),
+            });
+            continue;
+        }
+
+        // Anything else is a one-byte punctuation token. UTF-8 continuation
+        // bytes (high bit set, but not an identifier start per our check)
+        // are rare in punctuation and safe to treat as a single byte here.
+        let start = i;
+        let start_line = line;
+        // Advance by a full UTF-8 code point to avoid slicing inside one.
+        let step = utf8_char_len(b);
+        i += step;
+        let end = i.min(bytes.len());
+        out.push(Token {
+            kind: TokenKind::Punct,
+            start,
+            end,
+            line: start_line,
+            text: source[start..end].to_string(),
+        });
+    }
+
+    out
+}
+
+#[inline]
+fn is_ident_start(b: u8) -> bool {
+    b.is_ascii_alphabetic() || b == b'_' || b >= 0x80
+}
+
+#[inline]
+fn is_ident_continue(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b >= 0x80
+}
+
+#[inline]
+fn utf8_char_len(b: u8) -> usize {
+    match b {
+        0x00..=0x7F => 1,
+        0xC0..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xF7 => 4,
+        // Continuation byte in isolation; treat as 1 to make progress.
+        _ => 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kinds(src: &str) -> Vec<TokenKind> {
+        tokenize(src).into_iter().map(|t| t.kind).collect()
+    }
+
+    fn texts(src: &str) -> Vec<String> {
+        tokenize(src).into_iter().map(|t| t.text).collect()
+    }
+
+    #[test]
+    fn strips_whitespace() {
+        let toks = tokenize("  foo   bar\n\tbaz   ");
+        assert_eq!(
+            toks.iter().map(|t| t.text.as_str()).collect::<Vec<_>>(),
+            vec!["foo", "bar", "baz"]
+        );
+    }
+
+    #[test]
+    fn tracks_line_numbers() {
+        let toks = tokenize("a\nb\n\nc");
+        assert_eq!(toks[0].line, 1);
+        assert_eq!(toks[1].line, 2);
+        assert_eq!(toks[2].line, 4);
+    }
+
+    #[test]
+    fn line_comment_slash() {
+        let toks = tokenize("a // comment\nb");
+        assert_eq!(texts("a // comment\nb"), vec!["a", "b"]);
+        assert_eq!(toks[1].line, 2);
+    }
+
+    #[test]
+    fn block_comment() {
+        let toks = tokenize("a /* block\ncomment */ b");
+        assert_eq!(
+            toks.iter().map(|t| t.text.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+        assert_eq!(toks[1].line, 2, "line counter must span the block comment");
+    }
+
+    #[test]
+    fn line_comment_hash() {
+        assert_eq!(texts("a # python-style\nb"), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn string_literal_preserved_verbatim() {
+        let toks = tokenize(r#"let s = "hello world";"#);
+        let s = toks
+            .iter()
+            .find(|t| t.kind == TokenKind::String)
+            .expect("string token");
+        assert_eq!(s.text, "\"hello world\"");
+    }
+
+    #[test]
+    fn string_with_escaped_quote() {
+        let toks = tokenize(r#""a\"b""#);
+        assert_eq!(toks.len(), 1);
+        assert_eq!(toks[0].kind, TokenKind::String);
+        assert_eq!(toks[0].text, r#""a\"b""#);
+    }
+
+    #[test]
+    fn single_quoted_string() {
+        let toks = tokenize(r#"'hi'"#);
+        assert_eq!(toks.len(), 1);
+        assert_eq!(toks[0].kind, TokenKind::String);
+    }
+
+    #[test]
+    fn comment_markers_inside_strings_are_not_comments() {
+        let toks = tokenize(r#""// not a comment" x"#);
+        assert_eq!(toks.len(), 2);
+        assert_eq!(toks[0].kind, TokenKind::String);
+        assert_eq!(toks[1].kind, TokenKind::Identifier);
+    }
+
+    #[test]
+    fn numbers_and_decimals() {
+        assert_eq!(
+            kinds("42 3.14 0x1F 1_000 1e-3"),
+            vec![
+                TokenKind::Number,
+                TokenKind::Number,
+                TokenKind::Number,
+                TokenKind::Number,
+                TokenKind::Number
+            ]
+        );
+    }
+
+    #[test]
+    fn punctuation_tokens() {
+        let toks = tokenize("a+b;");
+        assert_eq!(
+            toks.iter().map(|t| t.kind).collect::<Vec<_>>(),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punct,
+                TokenKind::Identifier,
+                TokenKind::Punct
+            ]
+        );
+    }
+
+    #[test]
+    fn byte_spans_round_trip() {
+        let src = "foo  bar";
+        let toks = tokenize(src);
+        assert_eq!(&src[toks[0].start..toks[0].end], "foo");
+        assert_eq!(&src[toks[1].start..toks[1].end], "bar");
+    }
+
+    #[test]
+    fn non_ascii_identifier() {
+        let toks = tokenize("αβγ+δ");
+        // Expect two identifier tokens separated by punctuation.
+        assert_eq!(
+            toks.iter().map(|t| t.kind).collect::<Vec<_>>(),
+            vec![
+                TokenKind::Identifier,
+                TokenKind::Punct,
+                TokenKind::Identifier
+            ]
+        );
+    }
+
+    #[test]
+    fn comment_stripping_preserves_non_comment_token_count() {
+        let no_comments = "a b c d e";
+        let with_comments = "a /* x y z */ b // noise\nc # also\nd e";
+        assert_eq!(tokenize(no_comments).len(), tokenize(with_comments).len());
+    }
+
+    // --- proptest invariants -------------------------------------------------
+
+    use proptest::prelude::*;
+
+    fn strip_trailing_ws(s: &str) -> String {
+        s.lines()
+            .map(|l| l.trim_end())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Restrict to simple ASCII letters + spaces + newlines to keep the
+    /// whitespace-invariance property crisp. Comment markers, quotes, and
+    /// escapes are excluded so we can't accidentally generate a string
+    /// literal or comment mid-shuffle.
+    fn simple_source() -> impl Strategy<Value = String> {
+        proptest::collection::vec(
+            prop_oneof![
+                Just("a".to_string()),
+                Just("b".to_string()),
+                Just("c".to_string()),
+                Just("ident".to_string()),
+                Just("xyz".to_string()),
+                Just(" ".to_string()),
+                Just("  ".to_string()),
+                Just("\t".to_string()),
+                Just("\n".to_string()),
+            ],
+            0..40,
+        )
+        .prop_map(|v| v.concat())
+    }
+
+    proptest! {
+        /// Whitespace-only edits must not change the token kinds or texts.
+        #[test]
+        fn whitespace_edits_preserve_tokens(src in simple_source()) {
+            let original = tokenize(&src);
+            let stripped = tokenize(&strip_trailing_ws(&src));
+            let orig_texts: Vec<_> = original.iter().map(|t| (t.kind, t.text.clone())).collect();
+            let strip_texts: Vec<_> = stripped.iter().map(|t| (t.kind, t.text.clone())).collect();
+            prop_assert_eq!(orig_texts, strip_texts);
+        }
+
+        /// Tokenization is deterministic.
+        #[test]
+        fn deterministic(src in simple_source()) {
+            prop_assert_eq!(tokenize(&src), tokenize(&src));
+        }
+
+        /// Collapsing runs of interior whitespace to a single space must not
+        /// change the token stream (kinds + texts).
+        #[test]
+        fn collapsing_runs_of_whitespace_preserves_tokens(src in simple_source()) {
+            let collapsed: String = {
+                let mut out = String::new();
+                let mut prev_ws = false;
+                for ch in src.chars() {
+                    if ch.is_ascii_whitespace() {
+                        if !prev_ws { out.push(' '); }
+                        prev_ws = true;
+                    } else {
+                        out.push(ch);
+                        prev_ws = false;
+                    }
+                }
+                out
+            };
+            let a: Vec<_> = tokenize(&src).into_iter().map(|t| (t.kind, t.text)).collect();
+            let b: Vec<_> = tokenize(&collapsed).into_iter().map(|t| (t.kind, t.text)).collect();
+            prop_assert_eq!(a, b);
+        }
+    }
+}

--- a/crates/dedup-core/tests/scan.rs
+++ b/crates/dedup-core/tests/scan.rs
@@ -1,0 +1,94 @@
+//! Integration test: run [`Scanner::scan`] against the in-workspace
+//! `fixtures/tier_a_basic/` corpus and assert on the resulting match
+//! groups. The fixture contains three files with a known duplicated block
+//! (≥ 6 lines, ≥ 50 tokens). A passing scan proves the full Tier A pipeline
+//! end-to-end: walk → tokenize → rolling-hash → bucket → extend → filter.
+
+use std::path::PathBuf;
+
+use dedup_core::{ScanConfig, Scanner};
+
+fn workspace_root() -> PathBuf {
+    // `CARGO_MANIFEST_DIR` points at the crate dir; the workspace root is
+    // two levels up (`.../crates/dedup-core`).
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // dedup-core → crates
+    p.pop(); // crates     → workspace root
+    p
+}
+
+#[test]
+fn scans_tier_a_basic_fixture() {
+    let fixture = workspace_root().join("fixtures").join("tier_a_basic");
+    assert!(
+        fixture.exists(),
+        "fixture dir not found at {}",
+        fixture.display()
+    );
+
+    let scanner = Scanner::new(ScanConfig::default());
+    let result = scanner.scan(&fixture).expect("scan");
+
+    // 3 fixture files, all text.
+    assert_eq!(result.files_scanned, 3, "expected 3 files scanned");
+
+    // The shared duplicate block is ≥ 6 lines AND ≥ 50 tokens, so exactly
+    // one Tier A match group should be emitted.
+    assert_eq!(
+        result.groups.len(),
+        1,
+        "expected exactly 1 match group, got {:#?}",
+        result.groups
+    );
+    let group = &result.groups[0];
+    assert_eq!(group.occurrences.len(), 3, "expected 3 occurrences");
+
+    let paths: Vec<String> = group
+        .occurrences
+        .iter()
+        .map(|o| o.path.to_string_lossy().to_string())
+        .collect();
+    assert!(paths.iter().any(|p| p.contains("alpha.rs")));
+    assert!(paths.iter().any(|p| p.contains("beta.rs")));
+    assert!(paths.iter().any(|p| p.contains("gamma.rs")));
+
+    // Sanity-check: every occurrence should cover ≥ 6 lines.
+    for occ in &group.occurrences {
+        let line_span = occ.span.end_line - occ.span.start_line + 1;
+        assert!(
+            line_span >= 6,
+            "occurrence {:?} covers only {} lines",
+            occ.path,
+            line_span
+        );
+    }
+}
+
+#[test]
+fn output_lines_parseable_as_file_start_end() {
+    // Acceptance criterion: CLI emits lines suitable for `| xargs -o nvim`,
+    // which means `file:start-end`. We exercise the parse at the core level
+    // against a well-formed occurrence so the invariant is mechanical.
+    let fixture = workspace_root().join("fixtures").join("tier_a_basic");
+    let result = Scanner::new(ScanConfig::default())
+        .scan(&fixture)
+        .expect("scan");
+
+    for group in &result.groups {
+        for occ in &group.occurrences {
+            let line = format!(
+                "{}:{}-{}",
+                occ.path.display(),
+                occ.span.start_line,
+                occ.span.end_line
+            );
+            // path : start - end — the three fields round-trip.
+            let (path_part, range_part) = line.rsplit_once(':').expect("has colon");
+            let (start, end) = range_part.split_once('-').expect("has hyphen");
+            assert!(!path_part.is_empty());
+            let s: usize = start.parse().unwrap();
+            let e: usize = end.parse().unwrap();
+            assert!(s <= e);
+        }
+    }
+}

--- a/fixtures/tier_a_basic/alpha.rs
+++ b/fixtures/tier_a_basic/alpha.rs
@@ -1,0 +1,27 @@
+// alpha.rs — unique preamble so rolling-hash windows don't leak in.
+fn unique_alpha_preamble() {
+    let zzz = 0;
+    let yyy = 1;
+    let xxx = 2;
+}
+
+// --- shared duplicated block starts here ---
+fn compute_totals(rows: &[Row]) -> Total {
+    let mut sum = 0;
+    let mut count = 0;
+    for r in rows {
+        sum += r.value;
+        count += 1;
+    }
+    let mean = if count > 0 { sum / count } else { 0 };
+    let max = rows.iter().map(|r| r.value).max().unwrap_or(0);
+    let min = rows.iter().map(|r| r.value).min().unwrap_or(0);
+    Total { sum, count, mean, max, min }
+}
+// --- shared duplicated block ends here ---
+
+fn alpha_only_tail_zzz() {
+    let alpha_tail = 999;
+    let alpha_other = 888;
+    let alpha_third = 777;
+}

--- a/fixtures/tier_a_basic/beta.rs
+++ b/fixtures/tier_a_basic/beta.rs
@@ -1,0 +1,25 @@
+// beta.rs — different unique preamble.
+fn unique_beta_preamble() {
+    let qqq = 100;
+    let rrr = 200;
+}
+
+// --- shared duplicated block starts here ---
+fn compute_totals(rows: &[Row]) -> Total {
+    let mut sum = 0;
+    let mut count = 0;
+    for r in rows {
+        sum += r.value;
+        count += 1;
+    }
+    let mean = if count > 0 { sum / count } else { 0 };
+    let max = rows.iter().map(|r| r.value).max().unwrap_or(0);
+    let min = rows.iter().map(|r| r.value).min().unwrap_or(0);
+    Total { sum, count, mean, max, min }
+}
+// --- shared duplicated block ends here ---
+
+fn beta_only_tail_qqq() {
+    let beta_tail = 1234;
+    let beta_other = 5678;
+}

--- a/fixtures/tier_a_basic/gamma.rs
+++ b/fixtures/tier_a_basic/gamma.rs
@@ -1,0 +1,34 @@
+// gamma.rs — third copy lives further down the file.
+fn unique_gamma_preamble() {
+    let p1 = 1;
+    let p2 = 2;
+    let p3 = 3;
+    let p4 = 4;
+}
+
+// some more unique filler so the duplicate doesn't start on the same line
+fn unique_gamma_filler() {
+    let z = 42;
+}
+
+// --- shared duplicated block starts here ---
+fn compute_totals(rows: &[Row]) -> Total {
+    let mut sum = 0;
+    let mut count = 0;
+    for r in rows {
+        sum += r.value;
+        count += 1;
+    }
+    let mean = if count > 0 { sum / count } else { 0 };
+    let max = rows.iter().map(|r| r.value).max().unwrap_or(0);
+    let min = rows.iter().map(|r| r.value).min().unwrap_or(0);
+    Total { sum, count, mean, max, min }
+}
+// --- shared duplicated block ends here ---
+
+fn gamma_only_tail_ppp() {
+    let gamma_tail = 314;
+    let gamma_other = 271;
+    let gamma_third = 161;
+    let gamma_fourth = 141;
+}


### PR DESCRIPTION
## Summary

End-to-end Tier A tracer bullet: tokenizer -> rolling hash -> scanner -> CLI.
First real detection pipeline.

- `dedup-core` gets three deep, independently-testable modules:
  - `tokenizer`: language-oblivious lexer with `//` / `/* */` / `#` comment
    stripping, `"..."`/`'...'` string literal preservation (escape-aware),
    and 1-based line tracking.
  - `rolling_hash`: deterministic Rabin-Karp-style polynomial hash over
    token n-grams, emitting `(Hash, Span)` per window.
  - `scanner`: walks with `walkdir`, skips `.git/` + binary (NUL sniff of
    first 512 bytes), tokenizes UTF-8 files, rolls with n=50, buckets and
    greedily extends matches, filters by Tier A thresholds (>= 6 lines
    AND >= 50 tokens), returns `ScanResult`.
- `dedup-cli` gets a clap-derive `dedup scan [path]` command. Output is
  `--- group N (K occurrences) ---` headers plus `file:start-end` lines,
  suitable for `| xargs -o nvim`. Exit 0 regardless of findings
  (git-style; `--strict` lands in #13).
- Tests: unit + proptest invariants on tokenizer (whitespace/comment
  preservation, determinism) and rolling-hash (stability, span
  correctness, rolling vs. direct-recompute); scanner unit tests for the
  `.git/` skip, binary sniff, and threshold enforcement; integration
  test against `fixtures/tier_a_basic/` asserting exactly one match
  group with three occurrences; `insta` snapshot of the CLI stdout.

Out of scope per the PRD milestone seam: SQLite cache (#4), full ignore
layers via the `ignore` crate (#5), tree-sitter Tier B (#6), config
loading (#9), output formats (#12), flags like `--strict` (#13),
parallelism (#14), logging (#16).

Closes #3

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 36 tests passing (9 suites)
- [x] `dedup scan fixtures/tier_a_basic/` emits the expected match group
- [x] Output lines parse as `file:start-end`