### PR TITLE
feat: layered TOML config loader and `dedup config` subcommand (#9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,12 +241,15 @@ dependencies = [
 name = "dedup-core"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "insta",
  "proptest",
  "rusqlite",
  "rustc-hash",
+ "serde",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
+ "toml",
  "walkdir",
 ]
 
@@ -263,6 +266,27 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -330,6 +354,17 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -473,6 +508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +577,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pkg-config"
@@ -689,6 +739,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -823,6 +885,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -881,11 +952,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -898,6 +989,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unarray"
@@ -959,6 +1091,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1084,11 +1222,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1102,19 +1249,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1124,9 +1292,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1142,9 +1322,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1154,15 +1346,36 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/dedup-cli/src/main.rs
+++ b/crates/dedup-cli/src/main.rs
@@ -8,33 +8,39 @@
 //!   the same format as `scan` — no re-scan.
 //! - `show <id>`: print full detail (all occurrence spans) for one
 //!   persisted group.
+//! - `config`: inspect (`path`) or open (`edit`) the resolved config
+//!   file(s). Never auto-creates: the only place a config file is ever
+//!   materialized is `dedup config edit`, on explicit user action.
 //!
 //! # Global flags
 //!
 //! Flags live on [`GlobalArgs`], flattened into the top-level [`Cli`].
-//! Subcommand handlers read them via `cli.globals`. The bulk of this
-//! issue (#13) is wiring the flag surface — the tier/lang filters apply
-//! post-scan, `--strict` controls the exit code, progress is driven
-//! through the core's `ProgressSink` trait, and verbose / color / jobs
-//! flags are stored on the config for downstream issues (`#6` Tier B,
-//! `#14` parallelism, `#16` tracing subscriber) to pick up.
+//! Subcommand handlers read them via `cli.globals`. The bulk of the
+//! surface (see issue #13) wires the flag shape — the tier/lang filters
+//! apply post-scan, `--strict` controls the exit code, progress is
+//! driven through the core's `ProgressSink` trait, and verbose / color /
+//! jobs flags are stored on the config for downstream issues (`#6` Tier
+//! B, `#14` parallelism, `#16` tracing subscriber) to pick up.
 //!
 //! # Exit codes
 //!
 //! - `0` success (with or without findings; git-style default).
 //! - `1` findings present AND `--strict` was passed.
-//! - `2` config / usage / parse error (including clap parse errors —
-//!   the `main` function remaps clap's error kind to `2` before exit).
+//! - `2` config / usage / parse error (including clap parse errors and
+//!   invalid config files — the `main` function remaps clap's error
+//!   kind to `2` before exit).
 //! - `101` Rust panic (the default `panic = "unwind"` behavior; we do
 //!   not override it here).
 
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
-use std::process::ExitCode;
+use std::process::{Command as ProcessCommand, ExitCode};
 use std::time::Duration;
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
-use dedup_core::{Cache, GroupDetail, MatchGroup, ProgressSink, ScanConfig, Scanner};
+use dedup_core::{
+    Cache, Config, ConfigError, GroupDetail, MatchGroup, ProgressSink, ScanConfig, Scanner,
+};
 use indicatif::{ProgressBar, ProgressStyle};
 
 /// Root CLI parser. Subcommands live under [`Command`]; shared flags live
@@ -158,6 +164,33 @@ enum Command {
         #[arg(default_value = ".")]
         path: PathBuf,
     },
+    /// Inspect or edit the layered dedup config.
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ConfigAction {
+    /// Print the resolved config paths (global + project) with a
+    /// presence indicator for each layer.
+    Path {
+        /// Directory whose project config should be resolved. Defaults
+        /// to the current directory.
+        #[arg(default_value = ".")]
+        path: PathBuf,
+    },
+    /// Open the resolved config file in `$EDITOR` (falling back to
+    /// `$VISUAL`, then `vi`). If no config file exists, an empty one is
+    /// created at the project path — this is the one place a config
+    /// file is ever materialized.
+    Edit {
+        /// Directory whose project config should be edited. Defaults
+        /// to the current directory.
+        #[arg(default_value = ".")]
+        path: PathBuf,
+    },
 }
 
 /// Program entry point.
@@ -199,11 +232,37 @@ fn main() -> ExitCode {
         Command::Scan { ref path } => run_scan(path, &cli.globals),
         Command::List { ref path } => run_list(path, &cli.globals),
         Command::Show { id, ref path } => run_show(id, path, &cli.globals),
+        Command::Config { action } => match action {
+            ConfigAction::Path { path } => run_config_path(&path),
+            ConfigAction::Edit { path } => run_config_edit(&path),
+        },
     }
 }
 
 fn run_scan(path: &Path, globals: &GlobalArgs) -> ExitCode {
-    let scanner = Scanner::new(ScanConfig::default());
+    // Load layered config before scanning. Parse errors are fatal; a
+    // newer-schema file is treated as a warning and falls back to
+    // defaults (the `.bak` migration flow is deferred — see #9 spec).
+    let config = match Config::load(Some(path)) {
+        Ok(c) => c,
+        Err(ConfigError::SchemaVersionMismatch {
+            path: p,
+            found,
+            expected,
+        }) => {
+            eprintln!(
+                "dedup: warning: config at {} declares schema_version {found} which is newer than supported version {expected}; using defaults",
+                p.display()
+            );
+            Config::default()
+        }
+        Err(e) => {
+            eprintln!("dedup: config error: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let scanner = Scanner::new(ScanConfig::from(&config));
 
     // Build the progress sink. Spinner is suppressed when:
     // - stdout is not a TTY (piped output), OR
@@ -344,6 +403,104 @@ fn run_show(id: i64, path: &Path, _globals: &GlobalArgs) -> ExitCode {
     print_cached_group_show(&detail, &mut stdout).ok();
 
     ExitCode::SUCCESS
+}
+
+/// `dedup config path` — print one line per config layer with a
+/// presence indicator. Never creates files.
+fn run_config_path(path: &Path) -> ExitCode {
+    let global = Config::global_path();
+    let project = Config::project_path(path);
+    let mut stdout = std::io::stdout();
+    let _ = writeln!(stdout, "global: {} {}", global.display(), presence(&global));
+    let _ = writeln!(
+        stdout,
+        "project: {} {}",
+        project.display(),
+        presence(&project)
+    );
+    ExitCode::SUCCESS
+}
+
+/// `dedup config edit` — resolve to the preferred layer (project if the
+/// repo has a `.dedup/` directory, else global), create an empty file
+/// there if neither layer has one, then launch `$EDITOR`.
+fn run_config_edit(path: &Path) -> ExitCode {
+    let project = Config::project_path(path);
+    let global = Config::global_path();
+
+    // Prefer the project layer if the `.dedup/` directory already
+    // exists. Otherwise prefer whichever file actually exists. If
+    // neither exists, materialize an empty project-scoped file — this
+    // is the documented "one place" a config file is ever created.
+    let target = if path.join(".dedup").is_dir() || project.exists() {
+        project.clone()
+    } else if global.exists() {
+        global.clone()
+    } else {
+        project.clone()
+    };
+
+    if !target.exists() {
+        if let Some(parent) = target.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            eprintln!(
+                "dedup: failed to create config dir {}: {e}",
+                parent.display()
+            );
+            return ExitCode::from(2);
+        }
+        if let Err(e) = std::fs::write(&target, "") {
+            eprintln!(
+                "dedup: failed to create config file {}: {e}",
+                target.display()
+            );
+            return ExitCode::from(2);
+        }
+    }
+
+    let editor = resolve_editor();
+    let status = ProcessCommand::new(&editor).arg(&target).status();
+    match status {
+        Ok(s) if s.success() => ExitCode::SUCCESS,
+        Ok(s) => {
+            eprintln!(
+                "dedup: editor {} exited with status {}",
+                editor,
+                s.code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "?".into())
+            );
+            ExitCode::from(2)
+        }
+        Err(e) => {
+            eprintln!("dedup: failed to launch editor {editor}: {e}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+/// Resolve the editor command: `$EDITOR`, then `$VISUAL`, then `vi`.
+fn resolve_editor() -> String {
+    if let Ok(v) = std::env::var("EDITOR")
+        && !v.is_empty()
+    {
+        return v;
+    }
+    if let Ok(v) = std::env::var("VISUAL")
+        && !v.is_empty()
+    {
+        return v;
+    }
+    "vi".to_string()
+}
+
+fn presence(p: &Path) -> &'static str {
+    if p.exists() {
+        "(present)"
+    } else {
+        "(not present)"
+    }
 }
 
 /// Return true iff Tier A groups should be emitted given `--tier`.
@@ -582,5 +739,23 @@ mod tests {
             clap::error::ErrorKind::DisplayHelp,
             "unknown flag should not be help"
         );
+    }
+
+    #[test]
+    fn config_subcommand_parses() {
+        let cli = Cli::parse_from(["dedup", "config", "path"]);
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                action: ConfigAction::Path { .. }
+            }
+        ));
+        let cli = Cli::parse_from(["dedup", "config", "edit"]);
+        assert!(matches!(
+            cli.command,
+            Command::Config {
+                action: ConfigAction::Edit { .. }
+            }
+        ));
     }
 }

--- a/crates/dedup-cli/tests/config_cmd.rs
+++ b/crates/dedup-cli/tests/config_cmd.rs
@@ -32,7 +32,8 @@ fn copy_tree(src: &Path, dst: &Path) {
 }
 
 /// Build an `assert_cmd::Command` wired to a sandboxed HOME and empty
-/// XDG_CONFIG_HOME so `dirs::config_dir()` resolves below `home`.
+/// XDG_CONFIG_HOME so `Config::global_path()` resolves to
+/// `<home>/.config/dedup/config.toml`.
 fn dedup_with_home(home: &Path) -> Command {
     let mut cmd = Command::cargo_bin("dedup").unwrap();
     cmd.env("HOME", home).env_remove("XDG_CONFIG_HOME");

--- a/crates/dedup-cli/tests/config_cmd.rs
+++ b/crates/dedup-cli/tests/config_cmd.rs
@@ -1,0 +1,202 @@
+//! Integration tests for `dedup config` + config-aware `dedup scan`.
+//!
+//! Each test runs the compiled binary under a sandboxed HOME (set via
+//! env on the child process) so we never read or write the developer's
+//! real `~/.config/dedup/`. Repo-scoped project configs live in a
+//! `tempdir` and go away at test exit.
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+fn workspace_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop();
+    p.pop();
+    p
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let ty = entry.file_type().unwrap();
+        let target = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_tree(&entry.path(), &target);
+        } else if ty.is_file() {
+            std::fs::copy(entry.path(), &target).unwrap();
+        }
+    }
+}
+
+/// Build an `assert_cmd::Command` wired to a sandboxed HOME and empty
+/// XDG_CONFIG_HOME so `dirs::config_dir()` resolves below `home`.
+fn dedup_with_home(home: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("dedup").unwrap();
+    cmd.env("HOME", home).env_remove("XDG_CONFIG_HOME");
+    cmd
+}
+
+#[test]
+fn config_path_prints_both_layers_with_presence() {
+    let home = tempdir().unwrap();
+    let repo = tempdir().unwrap();
+
+    let out = dedup_with_home(home.path())
+        .arg("config")
+        .arg("path")
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{:?}", out);
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected two lines (global + project), got: {stdout:?}"
+    );
+    assert!(lines[0].starts_with("global: "), "bad line: {}", lines[0]);
+    assert!(lines[0].ends_with("(not present)"), "bad: {}", lines[0]);
+    assert!(lines[1].starts_with("project: "), "bad line: {}", lines[1]);
+    assert!(lines[1].ends_with("(not present)"), "bad: {}", lines[1]);
+}
+
+#[test]
+fn config_edit_creates_project_file_and_invokes_editor() {
+    let home = tempdir().unwrap();
+    let repo = tempdir().unwrap();
+
+    // `EDITOR=true` is a no-op editor available on every POSIX system:
+    // it simply exits 0 regardless of args.
+    let out = dedup_with_home(home.path())
+        .env("EDITOR", "true")
+        .env_remove("VISUAL")
+        .arg("config")
+        .arg("edit")
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "`dedup config edit` exited non-zero: {:?}",
+        out
+    );
+
+    // The project-scoped file was materialized.
+    let project_file = repo.path().join(".dedup").join("config.toml");
+    assert!(
+        project_file.exists(),
+        "expected {} to exist after edit",
+        project_file.display()
+    );
+}
+
+#[test]
+fn config_edit_falls_back_to_visual_when_editor_unset() {
+    let home = tempdir().unwrap();
+    let repo = tempdir().unwrap();
+
+    let out = dedup_with_home(home.path())
+        .env_remove("EDITOR")
+        .env("VISUAL", "true")
+        .arg("config")
+        .arg("edit")
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{:?}", out);
+    assert!(repo.path().join(".dedup").join("config.toml").exists());
+}
+
+#[test]
+fn scan_honors_project_config_thresholds_end_to_end() {
+    // Copy the real fixture, drop a project config that sets the Tier A
+    // threshold absurdly high, and assert that `scan` emits zero groups.
+    let home = tempdir().unwrap();
+    let repo = tempdir().unwrap();
+    let fixture = workspace_root().join("fixtures").join("tier_a_basic");
+    copy_tree(&fixture, repo.path());
+
+    // Bigger than any possible match in the fixture (files are < 50 LOC).
+    let dedup_dir = repo.path().join(".dedup");
+    std::fs::create_dir_all(&dedup_dir).unwrap();
+    std::fs::write(
+        dedup_dir.join("config.toml"),
+        r#"
+[thresholds.tier_a]
+min_lines = 1000
+min_tokens = 10000
+"#,
+    )
+    .unwrap();
+
+    let out = dedup_with_home(home.path())
+        .arg("scan")
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "scan failed: {:?}", out);
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.is_empty(),
+        "expected no groups with sky-high thresholds, got: {stdout:?}"
+    );
+}
+
+#[test]
+fn scan_with_invalid_config_exits_two_with_stderr_message() {
+    let home = tempdir().unwrap();
+    let repo = tempdir().unwrap();
+    let dedup_dir = repo.path().join(".dedup");
+    std::fs::create_dir_all(&dedup_dir).unwrap();
+    std::fs::write(dedup_dir.join("config.toml"), "this = = not valid\n").unwrap();
+
+    let out = dedup_with_home(home.path())
+        .arg("scan")
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("config error"),
+        "expected 'config error' in stderr, got: {stderr:?}"
+    );
+}
+
+#[test]
+fn scan_with_future_schema_warns_and_uses_defaults() {
+    // Fixture: two byte-identical files with a duplicate block large
+    // enough to clear the default tier_a thresholds.
+    let home = tempdir().unwrap();
+    let repo = tempdir().unwrap();
+    let fixture = workspace_root().join("fixtures").join("tier_a_basic");
+    copy_tree(&fixture, repo.path());
+
+    let dedup_dir = repo.path().join(".dedup");
+    std::fs::create_dir_all(&dedup_dir).unwrap();
+    std::fs::write(dedup_dir.join("config.toml"), "schema_version = 9999\n").unwrap();
+
+    let out = dedup_with_home(home.path())
+        .arg("scan")
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "expected success, got: {:?}", out);
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("schema_version"),
+        "expected schema_version warning in stderr, got: {stderr:?}"
+    );
+    // Defaults were applied, so the fixture's real duplicate block still
+    // gets detected.
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("--- group "),
+        "expected at least one group with defaults, got: {stdout:?}"
+    );
+}

--- a/crates/dedup-core/Cargo.toml
+++ b/crates/dedup-core/Cargo.toml
@@ -8,9 +8,12 @@ repository.workspace = true
 description = "Core detection, normalization, and persistence primitives for dedup."
 
 [dependencies]
+dirs = "5"
 rusqlite = { version = "0.32", features = ["bundled"] }
 rustc-hash = "2"
+serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+toml = "0.8"
 walkdir = "2"
 
 [dev-dependencies]

--- a/crates/dedup-core/src/config.rs
+++ b/crates/dedup-core/src/config.rs
@@ -247,14 +247,21 @@ impl PartialConfig {
 }
 
 impl Config {
-    /// Resolve the global config path: `$XDG_CONFIG_HOME/dedup/config.toml`
-    /// or `~/.config/dedup/config.toml` on POSIX, and the analogous
-    /// platform-specific path everywhere else (via the `dirs` crate).
+    /// Resolve the global config path.
+    ///
+    /// Per the PRD (GitHub issue #1), dedup stores its global state under
+    /// `~/.config/dedup/` on all platforms — this is literal and
+    /// load-bearing across the codebase (tracing logs and other future
+    /// features follow the same convention). On Unix we honor
+    /// `$XDG_CONFIG_HOME` when set, else fall back to
+    /// `$HOME/.config/dedup/config.toml`. On Windows (not in the CI
+    /// matrix) we fall back to `dirs::config_dir()` for lack of a sane
+    /// `~/.config` equivalent.
     pub fn global_path() -> PathBuf {
-        match dirs::config_dir() {
-            Some(p) => p.join(GLOBAL_CONFIG_SUBDIR).join(CONFIG_FILE),
-            None => PathBuf::from(CONFIG_FILE),
-        }
+        global_config_dir()
+            .unwrap_or_else(|| PathBuf::from(""))
+            .join(GLOBAL_CONFIG_SUBDIR)
+            .join(CONFIG_FILE)
     }
 
     /// Resolve the project config path for `repo_root`:
@@ -289,6 +296,25 @@ impl Config {
         }
 
         Ok(cfg)
+    }
+}
+
+/// Resolve the directory that contains the `dedup/` subdirectory for the
+/// global config. See [`Config::global_path`] for the platform rules.
+fn global_config_dir() -> Option<PathBuf> {
+    #[cfg(unix)]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+            let xdg = PathBuf::from(xdg);
+            if !xdg.as_os_str().is_empty() {
+                return Some(xdg);
+            }
+        }
+        dirs::home_dir().map(|h| h.join(".config"))
+    }
+    #[cfg(not(unix))]
+    {
+        dirs::config_dir()
     }
 }
 
@@ -329,11 +355,10 @@ mod tests {
     }
 
     /// Write a global config under the sandboxed `home`. Resolves the
-    /// actual global path (which varies by platform — `dirs::config_dir`
-    /// returns `~/Library/Application Support/` on macOS,
-    /// `~/.config/` on Linux). The env-override helper below has already
-    /// set HOME, so call this inside `with_test_home`'s closure if you
-    /// want the resolver and the writer to agree.
+    /// actual global path (`$HOME/.config/dedup/config.toml` on Unix per
+    /// the PRD). The env-override helper below has already set HOME, so
+    /// call this inside `with_test_home`'s closure if you want the
+    /// resolver and the writer to agree.
     fn write_global_under_home(home: &Path, body: &str) {
         with_test_home(home, || {
             let path = Config::global_path();
@@ -492,6 +517,50 @@ include_submodules = true
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn global_path_prefers_xdg_config_home_when_set() {
+        let home = tempdir().unwrap();
+        let xdg = tempdir().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: test-only env mutation; restored below.
+        unsafe {
+            std::env::set_var("HOME", home.path());
+            std::env::set_var("XDG_CONFIG_HOME", xdg.path());
+        }
+        let resolved = Config::global_path();
+        // Cleanup before assertions so failures don't leak state.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+        assert_eq!(
+            resolved,
+            xdg.path().join(GLOBAL_CONFIG_SUBDIR).join(CONFIG_FILE)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn global_path_falls_back_to_home_dot_config_without_xdg() {
+        let home = tempdir().unwrap();
+        let resolved = with_test_home(home.path(), Config::global_path);
+        assert_eq!(
+            resolved,
+            home.path()
+                .join(".config")
+                .join(GLOBAL_CONFIG_SUBDIR)
+                .join(CONFIG_FILE)
+        );
+    }
+
     #[test]
     fn absent_schema_version_is_treated_as_current() {
         let home = tempdir().unwrap();
@@ -509,9 +578,10 @@ min_lines = 7
         assert_eq!(cfg.thresholds.tier_a.min_lines, 7);
     }
 
-    /// Execute `f` with `$HOME` / `$XDG_CONFIG_HOME` set to `home` so
-    /// `dirs::config_dir()` resolves to `<home>/.config/` regardless of
-    /// the developer's real environment. Restores the environment after.
+    /// Execute `f` with `$HOME` set to `home` and `$XDG_CONFIG_HOME`
+    /// cleared so [`Config::global_path`] resolves to
+    /// `<home>/.config/dedup/config.toml` regardless of the developer's
+    /// real environment. Restores the environment after.
     ///
     /// Tests in this module are single-threaded within the module by
     /// convention (no explicit `#[serial]`) — these env mutations are

--- a/crates/dedup-core/src/config.rs
+++ b/crates/dedup-core/src/config.rs
@@ -1,0 +1,547 @@
+//! Layered TOML configuration for the dedup CLI and library.
+//!
+//! Resolution order (lowest precedence first):
+//!
+//! 1. Baked-in defaults ([`Config::default`]).
+//! 2. Global file at `~/.config/dedup/config.toml` (if present).
+//! 3. Project file at `<repo_root>/.dedup/config.toml` (if present).
+//!
+//! Merging is field-wise: any field set in a higher layer overrides the
+//! same field from a lower layer, nested tables flattened one level deep
+//! (`[thresholds.tier_a].min_lines` is its own mergeable field).
+//!
+//! Files are **never** auto-created. The only place a fresh file ever
+//! lands on disk is the CLI's `dedup config edit` subcommand — this
+//! module is strictly a loader.
+//!
+//! Future schema bumps: on load, if a file's `schema_version` is greater
+//! than [`SCHEMA_VERSION`], [`Config::load`] returns
+//! [`ConfigError::SchemaVersionMismatch`] so callers (today the CLI,
+//! later possibly a migrator per #17/#30) can decide whether to warn +
+//! fall back to defaults or rename the file to `.bak`. At this milestone
+//! the CLI just warns.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// The config schema version this build understands. Absent
+/// `schema_version` in a file defaults to 1.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Relative path of the per-project config inside the repo's `.dedup/`
+/// directory.
+pub const PROJECT_CONFIG_DIR: &str = ".dedup";
+/// File name of the config file inside [`PROJECT_CONFIG_DIR`] and inside
+/// `~/.config/dedup/`.
+pub const CONFIG_FILE: &str = "config.toml";
+/// Directory inside the user's config home where the global config lives.
+pub const GLOBAL_CONFIG_SUBDIR: &str = "dedup";
+
+/// Errors that can surface while loading or resolving configuration.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// IO failure while reading a config file we already believed exists.
+    #[error("config io error: {0}")]
+    Io(#[from] std::io::Error),
+    /// The file could not be parsed as valid TOML into our schema.
+    #[error("failed to parse config at {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    /// The file declared a `schema_version` greater than [`SCHEMA_VERSION`].
+    /// Callers decide whether to fall back to defaults.
+    #[error(
+        "config at {path} declares schema_version {found} which is newer than supported version {expected}"
+    )]
+    SchemaVersionMismatch {
+        path: PathBuf,
+        found: u32,
+        expected: u32,
+    },
+    /// `dirs::home_dir()` returned `None`. Rare, but possible on exotic
+    /// environments where there is no home concept.
+    #[error("could not locate the current user's home directory")]
+    HomeDirNotFound,
+}
+
+/// Tier A threshold tunables.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TierAThresholds {
+    pub min_lines: usize,
+    pub min_tokens: usize,
+}
+
+impl Default for TierAThresholds {
+    fn default() -> Self {
+        Self {
+            min_lines: 6,
+            min_tokens: 50,
+        }
+    }
+}
+
+/// Tier B threshold tunables. Tier B detection itself lands in #6; these
+/// values load through the schema today so later wiring is a no-op.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TierBThresholds {
+    pub min_lines: usize,
+    pub min_tokens: usize,
+}
+
+impl Default for TierBThresholds {
+    fn default() -> Self {
+        Self {
+            min_lines: 3,
+            min_tokens: 15,
+        }
+    }
+}
+
+/// Grouped Tier A + Tier B thresholds.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Thresholds {
+    pub tier_a: TierAThresholds,
+    pub tier_b: TierBThresholds,
+}
+
+/// Normalization strategy. `"conservative"` (default) keeps literals
+/// distinct. `"aggressive"` (wired in #10) abstracts string / numeric
+/// literals for broader matching. Today this key is loaded but only
+/// literally echoed back — it does not yet alter scanner behavior.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Normalization {
+    #[default]
+    Conservative,
+    Aggressive,
+}
+
+/// Scanner-side knobs: bytes budget per file, symlink + submodule
+/// policies. All wired straight through to `ScanConfig`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ScanSettings {
+    pub max_file_size: u64,
+    pub follow_symlinks: bool,
+    pub include_submodules: bool,
+}
+
+impl Default for ScanSettings {
+    fn default() -> Self {
+        Self {
+            max_file_size: 1_048_576,
+            follow_symlinks: false,
+            include_submodules: false,
+        }
+    }
+}
+
+/// The resolved config — always populated from the layering rules
+/// documented on [`Config::load`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Config {
+    pub schema_version: u32,
+    pub thresholds: Thresholds,
+    pub normalization: Normalization,
+    pub scan: ScanSettings,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            thresholds: Thresholds::default(),
+            normalization: Normalization::default(),
+            scan: ScanSettings::default(),
+        }
+    }
+}
+
+/// Raw deserialization target: every field wrapped in `Option<_>` so we
+/// can tell "unset" apart from "set to the default value" during the
+/// merge. The on-disk file does not need to specify every field.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct PartialConfig {
+    schema_version: Option<u32>,
+    thresholds: Option<PartialThresholds>,
+    normalization: Option<Normalization>,
+    scan: Option<PartialScanSettings>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct PartialThresholds {
+    tier_a: Option<PartialTierAThresholds>,
+    tier_b: Option<PartialTierBThresholds>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct PartialTierAThresholds {
+    min_lines: Option<usize>,
+    min_tokens: Option<usize>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct PartialTierBThresholds {
+    min_lines: Option<usize>,
+    min_tokens: Option<usize>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct PartialScanSettings {
+    max_file_size: Option<u64>,
+    follow_symlinks: Option<bool>,
+    include_submodules: Option<bool>,
+}
+
+impl PartialConfig {
+    fn apply_to(self, base: &mut Config) {
+        if let Some(v) = self.schema_version {
+            base.schema_version = v;
+        }
+        if let Some(t) = self.thresholds {
+            if let Some(a) = t.tier_a {
+                if let Some(v) = a.min_lines {
+                    base.thresholds.tier_a.min_lines = v;
+                }
+                if let Some(v) = a.min_tokens {
+                    base.thresholds.tier_a.min_tokens = v;
+                }
+            }
+            if let Some(b) = t.tier_b {
+                if let Some(v) = b.min_lines {
+                    base.thresholds.tier_b.min_lines = v;
+                }
+                if let Some(v) = b.min_tokens {
+                    base.thresholds.tier_b.min_tokens = v;
+                }
+            }
+        }
+        if let Some(n) = self.normalization {
+            base.normalization = n;
+        }
+        if let Some(s) = self.scan {
+            if let Some(v) = s.max_file_size {
+                base.scan.max_file_size = v;
+            }
+            if let Some(v) = s.follow_symlinks {
+                base.scan.follow_symlinks = v;
+            }
+            if let Some(v) = s.include_submodules {
+                base.scan.include_submodules = v;
+            }
+        }
+    }
+}
+
+impl Config {
+    /// Resolve the global config path: `$XDG_CONFIG_HOME/dedup/config.toml`
+    /// or `~/.config/dedup/config.toml` on POSIX, and the analogous
+    /// platform-specific path everywhere else (via the `dirs` crate).
+    pub fn global_path() -> PathBuf {
+        match dirs::config_dir() {
+            Some(p) => p.join(GLOBAL_CONFIG_SUBDIR).join(CONFIG_FILE),
+            None => PathBuf::from(CONFIG_FILE),
+        }
+    }
+
+    /// Resolve the project config path for `repo_root`:
+    /// `<repo_root>/.dedup/config.toml`.
+    pub fn project_path(repo_root: &Path) -> PathBuf {
+        repo_root.join(PROJECT_CONFIG_DIR).join(CONFIG_FILE)
+    }
+
+    /// Load and merge the layered config. `repo_root` is optional: when
+    /// `None`, only the global layer is consulted.
+    ///
+    /// Missing files are silently skipped (defaults-only is a valid and
+    /// common case). Parse failures and schema-version mismatches are
+    /// surfaced via [`ConfigError`].
+    pub fn load(repo_root: Option<&Path>) -> Result<Self, ConfigError> {
+        let mut cfg = Config::default();
+
+        let global = Self::global_path();
+        if global.exists() {
+            let partial = parse_partial(&global)?;
+            check_schema_version(&global, partial.schema_version)?;
+            partial.apply_to(&mut cfg);
+        }
+
+        if let Some(root) = repo_root {
+            let project = Self::project_path(root);
+            if project.exists() {
+                let partial = parse_partial(&project)?;
+                check_schema_version(&project, partial.schema_version)?;
+                partial.apply_to(&mut cfg);
+            }
+        }
+
+        Ok(cfg)
+    }
+}
+
+fn parse_partial(path: &Path) -> Result<PartialConfig, ConfigError> {
+    let body = std::fs::read_to_string(path)?;
+    toml::from_str::<PartialConfig>(&body).map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn check_schema_version(path: &Path, found: Option<u32>) -> Result<(), ConfigError> {
+    // Absent schema_version in the file is treated as the current version
+    // (the spec's default-via-serde behavior). Only an *explicit* newer
+    // value triggers the mismatch error.
+    if let Some(v) = found
+        && v > SCHEMA_VERSION
+    {
+        return Err(ConfigError::SchemaVersionMismatch {
+            path: path.to_path_buf(),
+            found: v,
+            expected: SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_project(root: &Path, body: &str) {
+        let dir = root.join(PROJECT_CONFIG_DIR);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(CONFIG_FILE), body).unwrap();
+    }
+
+    /// Write a global config under the sandboxed `home`. Resolves the
+    /// actual global path (which varies by platform — `dirs::config_dir`
+    /// returns `~/Library/Application Support/` on macOS,
+    /// `~/.config/` on Linux). The env-override helper below has already
+    /// set HOME, so call this inside `with_test_home`'s closure if you
+    /// want the resolver and the writer to agree.
+    fn write_global_under_home(home: &Path, body: &str) {
+        with_test_home(home, || {
+            let path = Config::global_path();
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, body).unwrap();
+        });
+    }
+
+    #[test]
+    fn default_round_trips_through_toml() {
+        let cfg = Config::default();
+        let rendered = toml::to_string(&cfg).unwrap();
+        let parsed: Config = toml::from_str(&rendered).unwrap();
+        assert_eq!(cfg, parsed);
+    }
+
+    #[test]
+    fn load_with_no_files_returns_defaults() {
+        // Point HOME at an empty tempdir so the global lookup misses.
+        let home = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let cfg = with_test_home(home.path(), || Config::load(Some(root.path())));
+        let cfg = cfg.unwrap();
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn load_respects_project_overrides() {
+        let home = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        write_project(
+            root.path(),
+            r#"
+schema_version = 1
+
+[thresholds.tier_a]
+min_lines = 42
+min_tokens = 123
+
+[scan]
+max_file_size = 2048
+follow_symlinks = true
+"#,
+        );
+        let cfg = with_test_home(home.path(), || Config::load(Some(root.path()))).unwrap();
+
+        assert_eq!(cfg.thresholds.tier_a.min_lines, 42);
+        assert_eq!(cfg.thresholds.tier_a.min_tokens, 123);
+        assert_eq!(cfg.scan.max_file_size, 2048);
+        assert!(cfg.scan.follow_symlinks);
+        // Fields the user didn't set still fall through to defaults.
+        assert_eq!(
+            cfg.thresholds.tier_b,
+            TierBThresholds::default(),
+            "tier_b untouched by project file"
+        );
+        assert!(!cfg.scan.include_submodules);
+    }
+
+    #[test]
+    fn project_overrides_global_and_global_overrides_defaults() {
+        let home = tempdir().unwrap();
+        // Global: bump tier_a.min_lines to 10, tier_b.min_tokens to 99.
+        write_global_under_home(
+            home.path(),
+            r#"
+[thresholds.tier_a]
+min_lines = 10
+
+[thresholds.tier_b]
+min_tokens = 99
+"#,
+        );
+
+        let root = tempdir().unwrap();
+        // Project: override tier_a.min_lines to 20. Leave tier_b alone.
+        write_project(
+            root.path(),
+            r#"
+[thresholds.tier_a]
+min_lines = 20
+"#,
+        );
+
+        let cfg = with_test_home(home.path(), || Config::load(Some(root.path()))).unwrap();
+
+        // Project beat global.
+        assert_eq!(cfg.thresholds.tier_a.min_lines, 20);
+        // Global's tier_a.min_tokens fallthrough is absent, so default.
+        assert_eq!(
+            cfg.thresholds.tier_a.min_tokens,
+            TierAThresholds::default().min_tokens
+        );
+        // Global applied where project didn't.
+        assert_eq!(cfg.thresholds.tier_b.min_tokens, 99);
+        // Defaults where neither layer said anything.
+        assert_eq!(
+            cfg.thresholds.tier_b.min_lines,
+            TierBThresholds::default().min_lines
+        );
+    }
+
+    #[test]
+    fn global_only_is_applied_when_no_repo_root() {
+        let home = tempdir().unwrap();
+        write_global_under_home(
+            home.path(),
+            r#"
+normalization = "aggressive"
+
+[scan]
+include_submodules = true
+"#,
+        );
+
+        let cfg = with_test_home(home.path(), || Config::load(None)).unwrap();
+        assert_eq!(cfg.normalization, Normalization::Aggressive);
+        assert!(cfg.scan.include_submodules);
+    }
+
+    #[test]
+    fn invalid_toml_surfaces_parse_error_with_path() {
+        let home = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        write_project(root.path(), "this is = = not valid toml\n");
+
+        let err = with_test_home(home.path(), || Config::load(Some(root.path()))).unwrap_err();
+        match err {
+            ConfigError::Parse { path, .. } => {
+                assert!(path.ends_with(PathBuf::from(PROJECT_CONFIG_DIR).join(CONFIG_FILE)));
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn newer_schema_version_is_rejected() {
+        let home = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        write_project(
+            root.path(),
+            &format!("schema_version = {}\n", SCHEMA_VERSION + 5),
+        );
+        let err = with_test_home(home.path(), || Config::load(Some(root.path()))).unwrap_err();
+        match err {
+            ConfigError::SchemaVersionMismatch {
+                path,
+                found,
+                expected,
+            } => {
+                assert!(path.ends_with(PathBuf::from(PROJECT_CONFIG_DIR).join(CONFIG_FILE)));
+                assert_eq!(found, SCHEMA_VERSION + 5);
+                assert_eq!(expected, SCHEMA_VERSION);
+            }
+            other => panic!("expected SchemaVersionMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn absent_schema_version_is_treated_as_current() {
+        let home = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        // No schema_version key — must load clean as current.
+        write_project(
+            root.path(),
+            r#"
+[thresholds.tier_a]
+min_lines = 7
+"#,
+        );
+        let cfg = with_test_home(home.path(), || Config::load(Some(root.path()))).unwrap();
+        assert_eq!(cfg.schema_version, SCHEMA_VERSION);
+        assert_eq!(cfg.thresholds.tier_a.min_lines, 7);
+    }
+
+    /// Execute `f` with `$HOME` / `$XDG_CONFIG_HOME` set to `home` so
+    /// `dirs::config_dir()` resolves to `<home>/.config/` regardless of
+    /// the developer's real environment. Restores the environment after.
+    ///
+    /// Tests in this module are single-threaded within the module by
+    /// convention (no explicit `#[serial]`) — these env mutations are
+    /// the reason, and the Rust test harness runs integration tests in
+    /// separate processes, so the global bleed risk is minimal. If this
+    /// ever bites, move to the `serial_test` crate.
+    fn with_test_home<F, R>(home: &Path, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // Force `dirs` to treat our tempdir as HOME and clear XDG so the
+        // fallback path `<home>/.config/` applies uniformly.
+        // SAFETY: test-only env mutation; the harness serializes tests
+        // that depend on env indirectly by restoring state at scope exit.
+        unsafe {
+            std::env::set_var("HOME", home);
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+        let out = f();
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            if let Some(v) = prev_xdg {
+                std::env::set_var("XDG_CONFIG_HOME", v);
+            }
+        }
+        out
+    }
+}

--- a/crates/dedup-core/src/lib.rs
+++ b/crates/dedup-core/src/lib.rs
@@ -20,11 +20,16 @@
 //! Tier B (#6), `ignore`-crate layers (#5), parallelism (#14), and so on.
 
 pub mod cache;
+pub mod config;
 pub mod rolling_hash;
 pub mod scanner;
 pub mod tokenizer;
 
 pub use cache::{Cache, CacheError, CachedOccurrence, GroupDetail, GroupSummary};
+pub use config::{
+    Config, ConfigError, Normalization, SCHEMA_VERSION as CONFIG_SCHEMA_VERSION, ScanSettings,
+    Thresholds, TierAThresholds, TierBThresholds,
+};
 pub use rolling_hash::{Hash, Span};
 pub use scanner::{
     MatchGroup, NoopSink, Occurrence, ProgressSink, ScanConfig, ScanError, ScanResult, Scanner,

--- a/crates/dedup-core/src/scanner.rs
+++ b/crates/dedup-core/src/scanner.rs
@@ -61,6 +61,18 @@ pub struct ScanConfig {
     pub tier_a_min_lines: usize,
     /// A match span must cover at least this many tokens to be reported.
     pub tier_a_min_tokens: usize,
+    /// Tier B minimum lines. Tier B detection lands in #6; today this
+    /// field is stored so the config→scanner bridge is one-shot.
+    pub tier_b_min_lines: usize,
+    /// Tier B minimum tokens.
+    pub tier_b_min_tokens: usize,
+    /// Files larger than this (in bytes) are skipped during scan.
+    pub max_file_size: u64,
+    /// If true, follow symlinks during the walk. Default false.
+    pub follow_symlinks: bool,
+    /// If true, descend into nested submodule directories (those
+    /// containing a `.git` file/dir). Default false.
+    pub include_submodules: bool,
 }
 
 impl Default for ScanConfig {
@@ -68,6 +80,25 @@ impl Default for ScanConfig {
         Self {
             tier_a_min_lines: 6,
             tier_a_min_tokens: 50,
+            tier_b_min_lines: 3,
+            tier_b_min_tokens: 15,
+            max_file_size: 1_048_576,
+            follow_symlinks: false,
+            include_submodules: false,
+        }
+    }
+}
+
+impl From<&crate::config::Config> for ScanConfig {
+    fn from(cfg: &crate::config::Config) -> Self {
+        Self {
+            tier_a_min_lines: cfg.thresholds.tier_a.min_lines,
+            tier_a_min_tokens: cfg.thresholds.tier_a.min_tokens,
+            tier_b_min_lines: cfg.thresholds.tier_b.min_lines,
+            tier_b_min_tokens: cfg.thresholds.tier_b.min_tokens,
+            max_file_size: cfg.scan.max_file_size,
+            follow_symlinks: cfg.scan.follow_symlinks,
+            include_submodules: cfg.scan.include_submodules,
         }
     }
 }
@@ -173,10 +204,32 @@ impl Scanner {
         // --- 1. Walk and tokenize each candidate file. --------------------
         let mut per_file: Vec<(PathBuf, Vec<Token>)> = Vec::new();
 
-        for entry in WalkDir::new(root).into_iter().filter_entry(|e| {
-            // Skip `.git/` directories wholesale.
-            !(e.file_type().is_dir() && e.file_name() == ".git")
-        }) {
+        let follow = self.config.follow_symlinks;
+        let include_submodules = self.config.include_submodules;
+        let max_bytes = self.config.max_file_size;
+
+        for entry in WalkDir::new(root)
+            .follow_links(follow)
+            .into_iter()
+            .filter_entry(|e| {
+                // Skip `.git/` directories wholesale.
+                if e.file_type().is_dir() && e.file_name() == ".git" {
+                    return false;
+                }
+                // Skip nested submodule directories unless explicitly
+                // asked to include them. A submodule is identified by a
+                // `.git` entry (file or dir) inside a directory *other
+                // than* the top-level root.
+                if !include_submodules
+                    && e.file_type().is_dir()
+                    && e.depth() > 0
+                    && e.path().join(".git").exists()
+                {
+                    return false;
+                }
+                true
+            })
+        {
             let entry = match entry {
                 Ok(e) => e,
                 // Tolerate per-entry walk errors (permission denied on a
@@ -189,6 +242,14 @@ impl Scanner {
             }
 
             let abs = entry.path();
+            // Honor the size cap before the full read — we still need
+            // metadata to make the decision, so a cheap `metadata()` is
+            // worth it over always loading the whole file.
+            if let Ok(meta) = entry.metadata()
+                && meta.len() > max_bytes
+            {
+                continue;
+            }
             let bytes = match std::fs::read(abs) {
                 Ok(b) => b,
                 Err(_) => continue,


### PR DESCRIPTION
## Summary

- Adds `dedup-core::config` with a layered TOML loader (defaults → `~/.config/dedup/config.toml` → `<repo>/.dedup/config.toml`) plus typed `ConfigError` (parse / schema-mismatch / home-dir-not-found).
- Wires `Config → ScanConfig` end-to-end: both tier thresholds plus `[scan]` (`max_file_size`, `follow_symlinks`, `include_submodules`) now drive the walker.
- Adds `dedup config path` (prints both layers with a presence indicator) and `dedup config edit` (materializes an empty project file if absent, then launches `$EDITOR` → `$VISUAL` → `vi`).
- Files are **never** auto-created by `scan`. The only on-disk write from this change lands inside `config edit`, on explicit user action.
- Schema-version mismatch: `ConfigError::SchemaVersionMismatch` is surfaced to callers; the CLI warns + falls back to defaults. The full `.bak` migration flow is intentionally deferred (per spec).
- Aggressive `normalization` key loads but is not yet consumed (lands in #10).

## Test plan
- [x] `cargo build --all`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --all-targets -- -D warnings`
- [x] `cargo test --all` (72 tests pass; 6 new CLI config integration tests + 8 new core config unit tests)
- [x] Manual smoke: `dedup config path` prints both layers; `dedup config edit` creates project file + launches editor; `dedup scan` with a project config honors thresholds end-to-end.

Closes #9