### PR TITLE
feat: tracing + logging infrastructure (#16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "dedup-cli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "clap",
  "dedup-core",
@@ -235,6 +251,8 @@ dependencies = [
  "insta",
  "predicates",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -250,16 +268,36 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
  "walkdir",
 ]
 
 [[package]]
 name = "dedup-gui"
 version = "0.1.0"
+dependencies = [
+ "filetime",
+ "tempfile",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "dedup-lang"
 version = "0.1.0"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "difflib"
@@ -327,6 +365,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -496,6 +545,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,7 +568,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -540,6 +598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +617,21 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -585,16 +667,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -736,6 +836,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -897,6 +1006,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +1037,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -991,6 +1115,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1196,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1311,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/crates/dedup-cli/Cargo.toml
+++ b/crates/dedup-cli/Cargo.toml
@@ -12,9 +12,12 @@ name = "dedup"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 dedup-core = { path = "../dedup-core" }
 indicatif = "0.17"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/dedup-cli/src/main.rs
+++ b/crates/dedup-cli/src/main.rs
@@ -20,7 +20,7 @@
 //! apply post-scan, `--strict` controls the exit code, progress is
 //! driven through the core's `ProgressSink` trait, and verbose / color /
 //! jobs flags are stored on the config for downstream issues (`#6` Tier
-//! B, `#14` parallelism, `#16` tracing subscriber) to pick up.
+//! B, `#14` parallelism) to pick up.
 //!
 //! # Exit codes
 //!
@@ -31,17 +31,30 @@
 //!   kind to `2` before exit).
 //! - `101` Rust panic (the default `panic = "unwind"` behavior; we do
 //!   not override it here).
+//!
+//! # Logging (issue #16)
+//!
+//! Library crates emit `tracing` events; this CLI installs a
+//! [`tracing_subscriber`] that writes to **stderr** with the pretty
+//! formatter. The filter is built from `RUST_LOG` if set, otherwise it
+//! defaults to `warn`. The `--verbose` / `-v` flag (owned by
+//! [`GlobalArgs`] per #13) lowers the default to `dedup=debug`, still
+//! overridable by `RUST_LOG`. Frontend errors use `anyhow::Result` with
+//! `.context(...)` for ergonomic propagation; library errors keep their
+//! `thiserror` enums per the PRD.
 
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, ExitCode};
 use std::time::Duration;
 
+use anyhow::{Context, Result};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use dedup_core::{
     Cache, Config, ConfigError, GroupDetail, MatchGroup, ProgressSink, ScanConfig, Scanner,
 };
 use indicatif::{ProgressBar, ProgressStyle};
+use tracing_subscriber::{EnvFilter, fmt};
 
 /// Root CLI parser. Subcommands live under [`Command`]; shared flags live
 /// on [`GlobalArgs`] and are flattened into this struct so every
@@ -102,9 +115,8 @@ pub struct GlobalArgs {
     #[arg(long, short = 'q', global = true, conflicts_with = "verbose")]
     pub quiet: bool,
 
-    /// Enable debug logging (`RUST_LOG=dedup=debug`). The env var is
-    /// set before any subscriber init; the subscriber itself lands in
-    /// #16.
+    /// Enable debug logging. Lowers the default `tracing` filter to
+    /// `dedup=debug`. `RUST_LOG` (when set) still wins.
     #[arg(long, short = 'v', action = ArgAction::SetTrue, global = true)]
     pub verbose: bool,
 
@@ -218,28 +230,53 @@ fn main() -> ExitCode {
         }
     };
 
-    // `-v` sets `RUST_LOG` early so the subscriber (landing in #16) can
-    // pick it up. We only set the env var if the user hasn't already
-    // overridden it — respect explicit `RUST_LOG=...` from the shell.
-    if cli.globals.verbose && std::env::var_os("RUST_LOG").is_none() {
-        // SAFETY: single-threaded at this point; nothing has spawned yet.
-        unsafe {
-            std::env::set_var("RUST_LOG", "dedup=debug");
-        }
-    }
+    // Install the tracing subscriber as early as possible so every
+    // downstream call (including the config load below) can emit.
+    init_logging(cli.globals.verbose);
 
-    match cli.command {
+    let result = match cli.command {
         Command::Scan { ref path } => run_scan(path, &cli.globals),
         Command::List { ref path } => run_list(path, &cli.globals),
         Command::Show { id, ref path } => run_show(id, path, &cli.globals),
         Command::Config { action } => match action {
-            ConfigAction::Path { path } => run_config_path(&path),
-            ConfigAction::Edit { path } => run_config_edit(&path),
+            ConfigAction::Path { path } => Ok(run_config_path(&path)),
+            ConfigAction::Edit { path } => Ok(run_config_edit(&path)),
         },
+    };
+
+    match result {
+        Ok(code) => code,
+        Err(err) => {
+            // `{:#}` prints the full anyhow chain on one line. Context
+            // strings added via `.context(...)` at call sites show up as
+            // the leading segment.
+            eprintln!("dedup: {err:#}");
+            ExitCode::from(2)
+        }
     }
 }
 
-fn run_scan(path: &Path, globals: &GlobalArgs) -> ExitCode {
+/// Install the process-wide [`tracing`] subscriber.
+///
+/// - Writes to stderr so scan output on stdout stays clean and pipeable.
+/// - Pretty formatter for human-readable dev output.
+/// - `EnvFilter` built from `RUST_LOG` when set; otherwise defaults to
+///   `warn` (or `dedup=debug` if `--verbose` was passed).
+///
+/// Idempotent enough in practice: `try_init` silently no-ops if a
+/// subscriber was already installed, which keeps integration tests that
+/// invoke the binary multiple times from panicking.
+fn init_logging(verbose: bool) {
+    let default = if verbose { "dedup=debug" } else { "warn" };
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default));
+    let _ = fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .pretty()
+        .try_init();
+}
+
+fn run_scan(path: &Path, globals: &GlobalArgs) -> Result<ExitCode> {
     // Load layered config before scanning. Parse errors are fatal; a
     // newer-schema file is treated as a warning and falls back to
     // defaults (the `.bak` migration flow is deferred — see #9 spec).
@@ -258,7 +295,7 @@ fn run_scan(path: &Path, globals: &GlobalArgs) -> ExitCode {
         }
         Err(e) => {
             eprintln!("dedup: config error: {e}");
-            return ExitCode::from(2);
+            return Ok(ExitCode::from(2));
         }
     };
 
@@ -276,13 +313,9 @@ fn run_scan(path: &Path, globals: &GlobalArgs) -> ExitCode {
         Box::new(dedup_core::NoopSink)
     };
 
-    let result = match scanner.scan_with_progress(path, sink.as_ref()) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("dedup: scan failed: {e}");
-            return ExitCode::from(2);
-        }
-    };
+    let result = scanner
+        .scan_with_progress(path, sink.as_ref())
+        .with_context(|| format!("scan failed for {}", path.display()))?;
 
     // Finalize the spinner before emitting any group text so progress
     // output doesn't collide with stdout lines.
@@ -317,31 +350,23 @@ fn run_scan(path: &Path, globals: &GlobalArgs) -> ExitCode {
     print_scan_groups(&visible, &mut std::io::stdout()).ok();
 
     if had_findings && globals.strict {
-        return ExitCode::from(1);
+        return Ok(ExitCode::from(1));
     }
-    ExitCode::SUCCESS
+    Ok(ExitCode::SUCCESS)
 }
 
-fn run_list(path: &Path, globals: &GlobalArgs) -> ExitCode {
-    let cache = match Cache::open_readonly(path) {
-        Ok(Some(c)) => c,
-        Ok(None) => {
+fn run_list(path: &Path, globals: &GlobalArgs) -> Result<ExitCode> {
+    let cache = match Cache::open_readonly(path)
+        .with_context(|| format!("failed to open cache at {}", path.display()))?
+    {
+        Some(c) => c,
+        None => {
             eprintln!("dedup: No cached scan found. Run `dedup scan` first.");
-            return ExitCode::from(2);
-        }
-        Err(e) => {
-            eprintln!("dedup: failed to open cache: {e}");
-            return ExitCode::from(2);
+            return Ok(ExitCode::from(2));
         }
     };
 
-    let groups = match cache.list_groups() {
-        Ok(g) => g,
-        Err(e) => {
-            eprintln!("dedup: failed to read cache: {e}");
-            return ExitCode::from(2);
-        }
-    };
+    let groups = cache.list_groups().context("failed to read cache")?;
 
     let allow_a = tier_allows_a(globals);
 
@@ -353,56 +378,52 @@ fn run_list(path: &Path, globals: &GlobalArgs) -> ExitCode {
         if !allow_a {
             continue;
         }
-        let detail = match cache.get_group(summary.id) {
-            Ok(Some(d)) => d,
-            Ok(None) => continue, // group vanished mid-read; skip.
-            Err(e) => {
-                eprintln!("dedup: failed to read group {}: {e}", summary.id);
-                return ExitCode::from(2);
-            }
+        let detail = match cache
+            .get_group(summary.id)
+            .with_context(|| format!("failed to read group {}", summary.id))?
+        {
+            Some(d) => d,
+            None => continue, // group vanished mid-read; skip.
         };
         if print_cached_group_full(ord + 1, &detail, &mut stdout).is_err() {
             // Broken pipe / closed stdout — treat as clean exit.
-            return ExitCode::SUCCESS;
+            return Ok(ExitCode::SUCCESS);
         }
         emitted += 1;
     }
 
     if emitted > 0 && globals.strict {
-        return ExitCode::from(1);
+        return Ok(ExitCode::from(1));
     }
-    ExitCode::SUCCESS
+    Ok(ExitCode::SUCCESS)
 }
 
-fn run_show(id: i64, path: &Path, _globals: &GlobalArgs) -> ExitCode {
-    let cache = match Cache::open_readonly(path) {
-        Ok(Some(c)) => c,
-        Ok(None) => {
+fn run_show(id: i64, path: &Path, _globals: &GlobalArgs) -> Result<ExitCode> {
+    let cache = match Cache::open_readonly(path)
+        .with_context(|| format!("failed to open cache at {}", path.display()))?
+    {
+        Some(c) => c,
+        None => {
             eprintln!("dedup: No cached scan found. Run `dedup scan` first.");
-            return ExitCode::from(2);
-        }
-        Err(e) => {
-            eprintln!("dedup: failed to open cache: {e}");
-            return ExitCode::from(2);
+            return Ok(ExitCode::from(2));
         }
     };
 
-    let detail = match cache.get_group(id) {
-        Ok(Some(d)) => d,
-        Ok(None) => {
+    let detail = match cache
+        .get_group(id)
+        .with_context(|| format!("failed to read group {id}"))?
+    {
+        Some(d) => d,
+        None => {
             eprintln!("dedup: no group with id {id}");
-            return ExitCode::from(2);
-        }
-        Err(e) => {
-            eprintln!("dedup: failed to read cache: {e}");
-            return ExitCode::from(2);
+            return Ok(ExitCode::from(2));
         }
     };
 
     let mut stdout = std::io::stdout();
     print_cached_group_show(&detail, &mut stdout).ok();
 
-    ExitCode::SUCCESS
+    Ok(ExitCode::SUCCESS)
 }
 
 /// `dedup config path` — print one line per config layer with a

--- a/crates/dedup-cli/tests/logging.rs
+++ b/crates/dedup-cli/tests/logging.rs
@@ -1,0 +1,131 @@
+//! Integration tests for issue #16: verify the CLI's `tracing` subscriber
+//! respects `RUST_LOG` and the `--verbose` flag.
+//!
+//! We run the compiled `dedup` binary against a copy of `fixtures/tier_a_basic`
+//! and inspect stderr. The library emits `info!` at scan start/end and
+//! `debug!` per tokenized file, so at `dedup=debug` level we always see at
+//! least one `DEBUG` line (the fixture has ≥ 1 text file) and at the
+//! default `warn` level we see none.
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+fn workspace_root() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.pop(); // dedup-cli → crates
+    p.pop(); // crates    → workspace root
+    p
+}
+
+fn copy_tree(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let file_type = entry.file_type().unwrap();
+        let target = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_tree(&entry.path(), &target);
+        } else if file_type.is_file() {
+            std::fs::copy(entry.path(), &target).unwrap();
+        }
+    }
+}
+
+fn copy_fixture() -> tempfile::TempDir {
+    let fixture = workspace_root().join("fixtures").join("tier_a_basic");
+    let tmp = tempdir().unwrap();
+    copy_tree(&fixture, tmp.path());
+    tmp
+}
+
+#[test]
+fn debug_events_appear_when_rust_log_enables_them() {
+    let tmp = copy_fixture();
+
+    let output = Command::cargo_bin("dedup")
+        .expect("dedup binary")
+        .env("RUST_LOG", "dedup=debug")
+        .arg("scan")
+        .arg(tmp.path())
+        .output()
+        .expect("dedup scan");
+
+    assert!(output.status.success(), "dedup scan failed: {:?}", output);
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(
+        stderr.contains("DEBUG"),
+        "expected at least one DEBUG line in stderr; got: {stderr}"
+    );
+}
+
+#[test]
+fn debug_events_are_filtered_out_by_default() {
+    let tmp = copy_fixture();
+
+    let output = Command::cargo_bin("dedup")
+        .expect("dedup binary")
+        .env_remove("RUST_LOG")
+        .arg("scan")
+        .arg(tmp.path())
+        .output()
+        .expect("dedup scan");
+
+    assert!(output.status.success(), "dedup scan failed: {:?}", output);
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(
+        !stderr.contains("DEBUG"),
+        "expected no DEBUG lines at default filter; got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("INFO"),
+        "expected no INFO lines at default `warn` filter; got: {stderr}"
+    );
+}
+
+#[test]
+fn verbose_flag_enables_debug_filter() {
+    let tmp = copy_fixture();
+
+    let output = Command::cargo_bin("dedup")
+        .expect("dedup binary")
+        .env_remove("RUST_LOG")
+        .arg("--verbose")
+        .arg("scan")
+        .arg(tmp.path())
+        .output()
+        .expect("dedup scan");
+
+    assert!(output.status.success(), "dedup scan failed: {:?}", output);
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    assert!(
+        stderr.contains("DEBUG"),
+        "expected DEBUG lines under --verbose; got: {stderr}"
+    );
+}
+
+#[test]
+fn cli_logs_land_on_stderr_not_stdout() {
+    // The scan `stdout` is the machine-parseable group listing; log
+    // output must stay on stderr so `dedup scan | xargs -o nvim` works.
+    let tmp = copy_fixture();
+
+    let output = Command::cargo_bin("dedup")
+        .expect("dedup binary")
+        .env("RUST_LOG", "dedup=debug")
+        .arg("scan")
+        .arg(tmp.path())
+        .output()
+        .expect("dedup scan");
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    assert!(
+        !stdout.contains("DEBUG"),
+        "DEBUG lines leaked onto stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("INFO"),
+        "INFO lines leaked onto stdout: {stdout}"
+    );
+}

--- a/crates/dedup-core/Cargo.toml
+++ b/crates/dedup-core/Cargo.toml
@@ -14,6 +14,7 @@ rustc-hash = "2"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 toml = "0.8"
+tracing = "0.1"
 walkdir = "2"
 
 [dev-dependencies]

--- a/crates/dedup-core/src/cache.rs
+++ b/crates/dedup-core/src/cache.rs
@@ -30,6 +30,7 @@ use std::path::{Path, PathBuf};
 
 use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use thiserror::Error;
+use tracing::{debug, info, warn};
 
 use crate::rolling_hash::Span;
 use crate::scanner::{MatchGroup, Occurrence, ScanResult};
@@ -135,6 +136,15 @@ impl Cache {
         configure_connection(&conn)?;
         ensure_schema(&conn)?;
 
+        let mode: String = conn
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .unwrap_or_default();
+        info!(
+            path = %db_path.display(),
+            journal_mode = %mode,
+            "cache: opened"
+        );
+
         Ok(Self { conn })
     }
 
@@ -162,6 +172,11 @@ impl Cache {
         // #18's job.
         let version = read_schema_version(&conn)?;
         if version > SCHEMA_VERSION {
+            warn!(
+                found = version,
+                supported = SCHEMA_VERSION,
+                "cache: schema newer than supported build"
+            );
             return Err(CacheError::FutureSchema {
                 found: version,
                 supported: SCHEMA_VERSION,
@@ -182,6 +197,11 @@ impl Cache {
     /// for now. #14 will wire real per-file content hashes into the
     /// warm-scan skip path; this issue only needs the row to exist.
     pub fn write_scan_result(&mut self, result: &ScanResult) -> Result<(), CacheError> {
+        debug!(
+            groups = result.groups.len(),
+            files_scanned = result.files_scanned,
+            "cache: write_scan_result"
+        );
         let tx = self.conn.transaction()?;
 
         // Fresh state — occurrences cascade from match_groups.
@@ -384,6 +404,11 @@ fn ensure_schema(conn: &Connection) -> Result<(), CacheError> {
     )?;
 
     if current > SCHEMA_VERSION {
+        warn!(
+            found = current,
+            supported = SCHEMA_VERSION,
+            "cache: schema newer than supported build"
+        );
         return Err(CacheError::FutureSchema {
             found: current,
             supported: SCHEMA_VERSION,

--- a/crates/dedup-core/src/scanner.rs
+++ b/crates/dedup-core/src/scanner.rs
@@ -32,6 +32,7 @@ use crate::tokenizer::{Token, tokenize};
 use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+use tracing::{debug, info, warn};
 use walkdir::WalkDir;
 
 /// The rolling-hash window size. Matches the Tier A `min_tokens` default.
@@ -201,6 +202,8 @@ impl Scanner {
         root: &Path,
         sink: &dyn ProgressSink,
     ) -> Result<ScanResult, ScanError> {
+        info!(root = %root.display(), "scan: starting");
+
         // --- 1. Walk and tokenize each candidate file. --------------------
         let mut per_file: Vec<(PathBuf, Vec<Token>)> = Vec::new();
 
@@ -234,8 +237,11 @@ impl Scanner {
                 Ok(e) => e,
                 // Tolerate per-entry walk errors (permission denied on a
                 // sibling, symlink loop, ...) so one bad file doesn't kill
-                // the scan. Logging lives in #16.
-                Err(_) => continue,
+                // the scan. Per-file graceful degradation lands in #17.
+                Err(e) => {
+                    warn!(error = %e, "scan: walkdir entry error, skipping");
+                    continue;
+                }
             };
             if !entry.file_type().is_file() {
                 continue;
@@ -252,18 +258,28 @@ impl Scanner {
             }
             let bytes = match std::fs::read(abs) {
                 Ok(b) => b,
-                Err(_) => continue,
+                Err(e) => {
+                    warn!(path = %abs.display(), error = %e, "scan: read failed, skipping");
+                    continue;
+                }
             };
             if looks_binary(&bytes) {
                 continue;
             }
             let text = match std::str::from_utf8(&bytes) {
                 Ok(s) => s.to_string(),
-                Err(_) => continue,
+                Err(e) => {
+                    // UTF-8 decode is routine in a mixed-encoding tree;
+                    // per the PRD this is debug-level, not warn.
+                    debug!(path = %abs.display(), error = %e, "scan: utf-8 decode failed, skipping");
+                    continue;
+                }
             };
 
             let rel = abs.strip_prefix(root).unwrap_or(abs).to_path_buf();
-            per_file.push((rel, tokenize(&text)));
+            let tokens = tokenize(&text);
+            debug!(path = %rel.display(), tokens = tokens.len(), "scan: tokenized file");
+            per_file.push((rel, tokens));
             // Report progress *after* the file is staged so sinks that
             // update a spinner see work that has actually been done.
             sink.on_file_processed(abs);
@@ -466,6 +482,8 @@ impl Scanner {
         for g in &groups {
             sink.on_match_group(g);
         }
+
+        info!(files_scanned, groups = groups.len(), "scan: complete");
 
         Ok(ScanResult {
             groups,

--- a/crates/dedup-gui/Cargo.toml
+++ b/crates/dedup-gui/Cargo.toml
@@ -8,3 +8,12 @@ repository.workspace = true
 description = "GPUI-based macOS frontend for dedup."
 
 [dependencies]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+filetime = "0.2"
+tempfile = "3"

--- a/crates/dedup-gui/src/lib.rs
+++ b/crates/dedup-gui/src/lib.rs
@@ -2,4 +2,16 @@
 //!
 //! The crate compiles as empty on non-macOS targets via the `cfg` gate
 //! below; the real GPUI integration lands in a later milestone.
+//!
+//! Issue #16 adds the logging infrastructure the GUI will wire up once
+//! the app skeleton (#19) lands. [`init_logging`] configures a layered
+//! [`tracing`] subscriber that writes JSON-formatted events to a
+//! daily-rolling file under `~/.config/dedup/logs/`. A companion pruning
+//! helper ([`prune_old_logs`]) keeps at most 7 files — `tracing-appender`
+//! rotates but does not garbage-collect, so the app calls the helper at
+//! startup.
 #![cfg(target_os = "macos")]
+
+mod logging;
+
+pub use logging::{LogGuard, MAX_LOG_FILES, init_logging, log_dir, prune_old_logs};

--- a/crates/dedup-gui/src/logging.rs
+++ b/crates/dedup-gui/src/logging.rs
@@ -1,0 +1,241 @@
+//! GUI logging: daily-rolling JSON log file + pruning helper.
+//!
+//! The macOS app installs a layered [`tracing`] subscriber that:
+//!
+//! - resolves `~/.config/dedup/logs/` via [`dirs::config_dir`] (creating
+//!   the directory on first run),
+//! - writes JSON events into `dedup.log.YYYY-MM-DD` files via
+//!   [`tracing_appender::rolling::daily`],
+//! - retains at most [`MAX_LOG_FILES`] files (manual prune on startup —
+//!   `tracing-appender` doesn't garbage-collect).
+//!
+//! The subscriber also honors `RUST_LOG` via [`EnvFilter`], defaulting to
+//! `info` when unset.
+//!
+//! This module intentionally does not initialize a subscriber at crate
+//! load time; the app's `main` calls [`init_logging`] once. Multiple
+//! calls are safe — the underlying `try_init` no-ops on re-install.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt;
+
+/// The log filename prefix used by the rolling appender. Rotated files
+/// are named `<prefix>.YYYY-MM-DD`, e.g. `dedup.log.2026-04-21`.
+const LOG_FILE_PREFIX: &str = "dedup.log";
+
+/// Maximum number of rotated log files to keep on disk.
+pub const MAX_LOG_FILES: usize = 7;
+
+/// Returned from [`init_logging`]. Holding it keeps the non-blocking
+/// appender's background worker alive; dropping it flushes remaining
+/// events. Apps typically bind it to a top-level variable in `main` that
+/// lives for the life of the process.
+#[must_use = "LogGuard flushes logs on drop — bind it to a variable in main()"]
+pub struct LogGuard {
+    _worker: WorkerGuard,
+}
+
+/// Resolve the dedup GUI log directory: `$XDG_CONFIG_HOME/dedup/logs/`,
+/// or on macOS where [`dirs::config_dir`] returns
+/// `$HOME/Library/Application Support`, override to the
+/// `~/.config/dedup/logs/` path the PRD specifies.
+///
+/// We deliberately prefer `$HOME/.config/dedup/logs/` over the macOS
+/// default Application Support directory because the PRD calls it out by
+/// name and because the GUI shares its log location conventions with the
+/// CLI on non-mac developer machines. Tests can redirect by setting
+/// `HOME` (or `XDG_CONFIG_HOME`).
+pub fn log_dir() -> io::Result<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME")
+        && !xdg.is_empty()
+    {
+        return Ok(PathBuf::from(xdg).join("dedup").join("logs"));
+    }
+    let home = std::env::var_os("HOME").ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "HOME environment variable not set; cannot resolve log directory",
+        )
+    })?;
+    Ok(PathBuf::from(home)
+        .join(".config")
+        .join("dedup")
+        .join("logs"))
+}
+
+/// Install the GUI [`tracing`] subscriber.
+///
+/// Creates the log directory if missing, prunes stale files, installs a
+/// daily-rolling JSON-formatting appender, and returns a [`LogGuard`]
+/// the caller must keep alive for the lifetime of the process.
+pub fn init_logging() -> io::Result<LogGuard> {
+    let dir = log_dir()?;
+    fs::create_dir_all(&dir)?;
+
+    // Prune on startup so a long-lived machine with daily logs doesn't
+    // accumulate indefinitely.
+    if let Err(e) = prune_old_logs(&dir, MAX_LOG_FILES) {
+        // Pruning is best-effort — a failure here should not block the
+        // app from starting. Emit via eprintln since tracing isn't
+        // installed yet.
+        eprintln!("dedup-gui: log pruning failed: {e}");
+    }
+
+    let appender = rolling::daily(&dir, LOG_FILE_PREFIX);
+    let (writer, worker) = tracing_appender::non_blocking(appender);
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = fmt()
+        .json()
+        .with_env_filter(filter)
+        .with_writer(writer)
+        .try_init();
+
+    Ok(LogGuard { _worker: worker })
+}
+
+/// Delete rotated log files beyond the `keep` most recent by mtime.
+///
+/// Matches files whose name starts with [`LOG_FILE_PREFIX`] and has a
+/// date-like suffix — i.e. the filenames `tracing-appender` rotates to.
+/// The "current" (undated) base file, if any, is left alone.
+///
+/// Returns the number of files removed.
+pub fn prune_old_logs(dir: &Path, keep: usize) -> io::Result<usize> {
+    if !dir.exists() {
+        return Ok(0);
+    }
+
+    let mut candidates: Vec<(PathBuf, std::time::SystemTime)> = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !is_rotated_log(&name) {
+            continue;
+        }
+        let meta = entry.metadata()?;
+        let mtime = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        candidates.push((entry.path(), mtime));
+    }
+
+    // Newest first.
+    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+
+    let mut removed = 0usize;
+    for (path, _) in candidates.into_iter().skip(keep) {
+        match fs::remove_file(&path) {
+            Ok(()) => removed += 1,
+            Err(e) => {
+                // Surface but continue; a file we couldn't delete this
+                // run will be retried on the next app start.
+                eprintln!("dedup-gui: failed to delete {}: {e}", path.display());
+            }
+        }
+    }
+    Ok(removed)
+}
+
+/// Recognize a filename as a rotated dedup log file.
+///
+/// Matches `dedup.log.<suffix>` where the suffix is non-empty — e.g.
+/// `dedup.log.2026-04-21`. The bare `dedup.log` base file (if the
+/// appender ever produces one) is excluded so we never prune the
+/// currently-active file.
+fn is_rotated_log(name: &str) -> bool {
+    match name.strip_prefix(LOG_FILE_PREFIX) {
+        Some(rest) => rest.starts_with('.') && rest.len() > 1,
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+    use tempfile::tempdir;
+
+    #[test]
+    fn is_rotated_log_matches_dated_files() {
+        assert!(is_rotated_log("dedup.log.2026-04-21"));
+        assert!(is_rotated_log("dedup.log.2026-01-01"));
+    }
+
+    #[test]
+    fn is_rotated_log_rejects_unrelated_files() {
+        assert!(!is_rotated_log("dedup.log"));
+        assert!(!is_rotated_log("other.log.2026-04-21"));
+        assert!(!is_rotated_log("dedup.logs"));
+        assert!(!is_rotated_log("README.md"));
+    }
+
+    #[test]
+    fn prune_keeps_newest_n_by_mtime() {
+        let dir = tempdir().unwrap();
+        // Create 10 rotated files with strictly-increasing mtimes so the
+        // prune order is deterministic.
+        let now = SystemTime::now();
+        let mut expected_kept: Vec<PathBuf> = Vec::new();
+        for i in 0..10 {
+            let name = format!("dedup.log.2026-04-{:02}", i + 1);
+            let p = dir.path().join(&name);
+            fs::write(&p, b"").unwrap();
+            // Older index → older mtime.
+            let mtime = now - Duration::from_secs(((10 - i) * 3600) as u64);
+            filetime::set_file_mtime(&p, filetime::FileTime::from_system_time(mtime)).unwrap();
+            if i >= 3 {
+                expected_kept.push(p);
+            }
+        }
+
+        let removed = prune_old_logs(dir.path(), MAX_LOG_FILES).unwrap();
+        assert_eq!(removed, 3);
+
+        let remaining: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .collect();
+        assert_eq!(remaining.len(), MAX_LOG_FILES);
+    }
+
+    #[test]
+    fn prune_is_noop_when_under_limit() {
+        let dir = tempdir().unwrap();
+        for i in 0..3 {
+            let name = format!("dedup.log.2026-04-{:02}", i + 1);
+            fs::write(dir.path().join(&name), b"").unwrap();
+        }
+        let removed = prune_old_logs(dir.path(), MAX_LOG_FILES).unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn prune_ignores_unrelated_files() {
+        let dir = tempdir().unwrap();
+        for i in 0..10 {
+            let name = format!("dedup.log.2026-04-{:02}", i + 1);
+            fs::write(dir.path().join(&name), b"").unwrap();
+        }
+        fs::write(dir.path().join("unrelated.txt"), b"x").unwrap();
+
+        prune_old_logs(dir.path(), MAX_LOG_FILES).unwrap();
+        assert!(dir.path().join("unrelated.txt").exists());
+    }
+
+    #[test]
+    fn prune_on_missing_dir_returns_zero() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nope");
+        assert_eq!(prune_old_logs(&missing, MAX_LOG_FILES).unwrap(), 0);
+    }
+}

--- a/crates/dedup-gui/src/logging.rs
+++ b/crates/dedup-gui/src/logging.rs
@@ -129,7 +129,7 @@ pub fn prune_old_logs(dir: &Path, keep: usize) -> io::Result<usize> {
     }
 
     // Newest first.
-    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    candidates.sort_by_key(|(_, mtime)| std::cmp::Reverse(*mtime));
 
     let mut removed = 0usize;
     for (path, _) in candidates.into_iter().skip(keep) {

--- a/crates/dedup-gui/tests/logging_smoke.rs
+++ b/crates/dedup-gui/tests/logging_smoke.rs
@@ -1,0 +1,145 @@
+//! Smoke test for the GUI logging subscriber (issue #16).
+//!
+//! Verifies:
+//!
+//! 1. [`init_logging`] materializes the target log directory and produces
+//!    at least one `dedup.log.*` file when a `tracing` event is emitted.
+//! 2. [`prune_old_logs`] enforces the 7-file retention cap.
+//!
+//! Runs only on macOS because the GUI crate itself is macOS-gated.
+
+#![cfg(target_os = "macos")]
+
+use std::fs;
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime};
+
+use dedup_gui::{MAX_LOG_FILES, init_logging, log_dir, prune_old_logs};
+
+/// Tests in this file mutate the process-wide `HOME`/`XDG_CONFIG_HOME`
+/// env vars; cargo runs them in parallel within the same binary by
+/// default, so we serialize with a mutex. Combining into one giant
+/// `#[test]` would hide which assertion failed, so we pay the mutex.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Install a temp `HOME` for the duration of the test so
+/// `~/.config/dedup/logs/` resolves under the tempdir. We also clear
+/// `XDG_CONFIG_HOME` so the HOME-relative path wins.
+struct HomeGuard {
+    _tmp: tempfile::TempDir,
+    canonical: std::path::PathBuf,
+    prev_home: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl HomeGuard {
+    fn install() -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        // On macOS `tempdir()` returns something like `/var/folders/...`
+        // which `fs::canonicalize` resolves to `/private/var/folders/...`.
+        // We need the canonicalized form for the `starts_with` assertion
+        // because that's what `init_logging` ends up joining against.
+        let canonical = fs::canonicalize(tmp.path()).unwrap();
+        let prev_home = std::env::var_os("HOME");
+        let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: the `ENV_LOCK` mutex above ensures at most one
+        // `HomeGuard` exists at a time within this test binary. Other
+        // test binaries run in their own processes and so can't race.
+        unsafe {
+            std::env::set_var("HOME", &canonical);
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+        Self {
+            _tmp: tmp,
+            canonical,
+            prev_home,
+            prev_xdg,
+            _lock: lock,
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.canonical
+    }
+}
+
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match &self.prev_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+}
+
+#[test]
+fn init_logging_creates_dir_and_writes_a_file() {
+    let home = HomeGuard::install();
+
+    let guard = init_logging().expect("init_logging must not panic");
+
+    // Resolve the directory the same way `init_logging` did.
+    let dir = log_dir().unwrap();
+    assert!(
+        dir.starts_with(home.path()),
+        "log dir {:?} should live under temp HOME {:?}",
+        dir,
+        home.path()
+    );
+    assert!(dir.exists(), "log dir materialized");
+
+    // Emit an event through the global subscriber so the appender has
+    // something to flush to disk.
+    tracing::info!("smoke test event");
+
+    // Drop the guard → flushes the non-blocking worker.
+    drop(guard);
+
+    let files: Vec<_> = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with("dedup.log"))
+        .collect();
+    assert!(
+        !files.is_empty(),
+        "at least one dedup.log.* file should exist after init_logging; saw {files:?}"
+    );
+}
+
+#[test]
+fn prune_retains_seven_most_recent() {
+    let home = HomeGuard::install();
+    let dir = home.path().join(".config").join("dedup").join("logs");
+    fs::create_dir_all(&dir).unwrap();
+
+    // 10 rotated files with strictly-increasing mtimes.
+    let now = SystemTime::now();
+    for i in 0..10 {
+        let name = format!("dedup.log.2026-04-{:02}", i + 1);
+        let p = dir.join(&name);
+        fs::write(&p, b"").unwrap();
+        let mtime = now - Duration::from_secs(((10 - i) * 3600) as u64);
+        filetime::set_file_mtime(&p, filetime::FileTime::from_system_time(mtime)).unwrap();
+    }
+
+    let removed = prune_old_logs(&dir, MAX_LOG_FILES).unwrap();
+    assert_eq!(removed, 3, "should remove the 3 oldest");
+
+    let remaining: Vec<_> = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.starts_with("dedup.log"))
+        .collect();
+    assert_eq!(remaining.len(), MAX_LOG_FILES);
+}

--- a/crates/dedup-lang/Cargo.toml
+++ b/crates/dedup-lang/Cargo.toml
@@ -8,3 +8,4 @@ repository.workspace = true
 description = "Language profiles (generic Tier A + Rust / TypeScript / Python Tier B) for dedup."
 
 [dependencies]
+tracing = "0.1"


### PR DESCRIPTION
## Summary

Wires `tracing` + `tracing-subscriber` across the workspace. Library
crates (`dedup-core`, `dedup-lang`, `dedup-gui`) emit events;
frontends (`dedup-cli`, `dedup-gui`) install subscribers.

- **CLI**: pretty stderr subscriber, `EnvFilter` from `RUST_LOG`
  (default `warn`). New `-v` / `--verbose` flag lowers the default to
  `dedup=debug` (still overridable by `RUST_LOG`). `main` converted to
  `anyhow::Result` with `.context(...)` at call sites; library crates
  keep their `thiserror` enums per PRD.
- **GUI** (macOS-only, cfg-gated): JSON-formatted daily-rolling
  appender at `~/.config/dedup/logs/dedup.log.*` via
  `tracing-appender`. Manual retention cap of 7 files enforced by a
  startup prune helper (tracing-appender does not auto-limit).
- **Instrumentation**: `scanner` logs scan start/end + stats, per-file
  tokenization (debug), read/walk failures (warn), UTF-8 decode
  failures (debug per PRD — routine); `cache` logs open + journal
  mode (info), write_scan_result group count (debug), future-schema
  refusal (warn). `tokenizer` stays unlogged (too hot).

## Acceptance criteria

- [x] CLI logs land on stderr with pretty formatter; `RUST_LOG` respected
- [x] GUI logs rotate daily at `~/.config/dedup/logs/` with JSON format
- [x] Max 7 log files retained (prune helper + test)
- [x] `-v` enables `dedup=debug` filter
- [x] Library crates use `thiserror`; frontends use `anyhow`
- [x] `cargo build` / `fmt` / `clippy -D warnings` / `test` all clean

## Test plan

- [x] `cargo test --workspace` — 70/70 pass locally on macOS
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `dedup-cli/tests/logging.rs` covers: `RUST_LOG=dedup=debug`
  surfaces DEBUG lines; default filter suppresses DEBUG + INFO;
  `--verbose` surfaces DEBUG; DEBUG never leaks to stdout
- [x] `dedup-gui/tests/logging_smoke.rs` covers:
  `init_logging()` materializes a `dedup.log.*` file under temp
  `HOME`; 10 rotated files → 7 remain after `prune_old_logs`

## Out of scope (per issue)

Per-file error graceful degradation (→ #17). `human-panic` integration
(→ #17). Toast / modal error UX (→ #30). Log attachment "copy details"
UI (→ #30).

Closes #16.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>